### PR TITLE
Force dns resolution on connection retry

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -630,6 +630,7 @@ public final class MemcachedConnection extends SpyObject implements Reconfigurab
 			try {
 				if(!seen.containsKey(qa)) {
 					seen.put(qa, Boolean.TRUE);
+					qa.forceDnsResolution();
 					getLogger().info("Reconnecting %s", qa);
 					ch=SocketChannel.open();
 					ch.configureBlocking(false);

--- a/src/main/java/net/spy/memcached/MemcachedNode.java
+++ b/src/main/java/net/spy/memcached/MemcachedNode.java
@@ -113,6 +113,12 @@ public interface MemcachedNode {
 	SocketAddress getSocketAddress();
 
 	/**
+	 * Used to force dns resolution before reconnecting. For those of us in the
+	 * cloud w/o control over IP's.
+	 */
+	void forceDnsResolution();
+
+	/**
 	 * True if this node is <q>active.</q>  i.e. is is currently connected
 	 * and expected to be able to process requests
 	 */

--- a/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
+++ b/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
@@ -86,6 +86,10 @@ class MemcachedNodeROImpl implements MemcachedNode {
 		return root.getSocketAddress();
 	}
 
+	public void forceDnsResolution() {
+		throw new UnsupportedOperationException();
+	}
+
 	public ByteBuffer getWbuf() {
 		throw new UnsupportedOperationException();
 	}

--- a/src/test/java/net/spy/memcached/MockMemcachedNode.java
+++ b/src/test/java/net/spy/memcached/MockMemcachedNode.java
@@ -16,6 +16,7 @@ import net.spy.memcached.ops.Operation;
 public class MockMemcachedNode implements MemcachedNode {
 	private final InetSocketAddress socketAddress;
 	public SocketAddress getSocketAddress() {return socketAddress;}
+	public void forceDnsResolution() {;}
 
 	public MockMemcachedNode(InetSocketAddress socketAddress) {
 		this.socketAddress = socketAddress;


### PR DESCRIPTION
DNS resolution is only done once on initialization. We can trigger memcached clients to reload through zookeeper. It appears many java systems do not listen for changed zookeeper params as evidenced after the past few memcached swaps. Forcing DNS resolution should provide a nice catch all solution for the stragglers.

With this in place, we'll be able to change the zookeeper param which will trigger many java apps to properly fail over to the new memcached server(s). The next step is always to flush the cache on the old memcached servers. Instead of flushing the cache via the memcached protocol, we can restart the process. The changes in this PR will be triggered by that connection being dropped and will reconnect to the new memcached servers.
