### PR TITLE
Force dns on reconnect

### DIFF
--- a/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
@@ -379,7 +379,7 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject
 			if (newSa.isUnresolved()) {
 				getLogger().warn("New socket address created was unresolvable: %s", newSa);
 			} else if (!newSa.equals(sa)) {
-				getLogger().info("Dns appears to have changed, socket address from: %s, to: %s", getSocketAddress(), newSa);
+				getLogger().info("Dns appears to have changed, socket address from: %s, to: %s", sa, newSa);
 				setSocketAddress(newSa);
 			}
 		}

--- a/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
@@ -375,9 +375,13 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject
 	public void forceDnsResolution() {
 		SocketAddress sa = getSocketAddress();
 		if (sa instanceof InetSocketAddress) {
-			getLogger().info("forcing dns resolution, current socket address is: "+ sa);
-			setSocketAddress(new InetSocketAddress(((InetSocketAddress)sa).getHostString(), ((InetSocketAddress)sa).getPort()));
-			getLogger().info("forcing dns resolution, new socket address is: "+ getSocketAddress());
+			InetSocketAddress newSa = new InetSocketAddress(((InetSocketAddress)sa).getHostName(), ((InetSocketAddress)sa).getPort());
+			if (newSa.isUnresolved()) {
+				getLogger().warn("New socket address created was unresolvable: %s", newSa);
+			} else if (!newSa.equals(sa)) {
+				getLogger().info("Dns appears to have changed, socket address from: %s, to: %s", getSocketAddress(), newSa);
+				setSocketAddress(newSa);
+			}
 		}
 	}
 


### PR DESCRIPTION
Reimplemented w/o very useful jdk1.7 method. This latest version is also a bit more conservative about actually resetting the in place SocketAddress, in particular will verify the address is resolved.
