### PR TITLE
Added minimum time threshold when triggering connection lost

### DIFF
--- a/src/main/java/net/spy/memcached/ConnectionFactory.java
+++ b/src/main/java/net/spy/memcached/ConnectionFactory.java
@@ -137,4 +137,9 @@ public interface ConnectionFactory {
 	 * Maximum number of timeout exception for shutdown connection
 	 */
 	int getTimeoutExceptionThreshold();
+
+	/**
+	 * Minimum number of millis of continuous timeout exceptions before shutting down a connection
+	 */
+	long getTimeoutExceptionDurationThreshold();
 }

--- a/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
+++ b/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
@@ -46,6 +46,7 @@ public class ConnectionFactoryBuilder {
 	private long opQueueMaxBlockTime = -1;
 
 	private int timeoutExceptionThreshold = DefaultConnectionFactory.DEFAULT_MAX_TIMEOUTEXCEPTION_THRESHOLD;
+	private long timeoutExceptionDurationThreshold = DefaultConnectionFactory.DEFAULT_MAX_TIMEOUTEXCEPTION_DURATION_THRESHOLD;
     private Config vBucketConfig;
 	/**
 	 * Set the operation queue factory.
@@ -67,6 +68,7 @@ public class ConnectionFactoryBuilder {
 		setReadBufferSize(cf.getReadBufSize());
 		setShouldOptimize(cf.shouldOptimize());
 		setTimeoutExceptionThreshold(cf.getTimeoutExceptionThreshold());
+		setTimeoutExceptionDurationThreshold(cf.getTimeoutExceptionDurationThreshold());
 		setTranscoder(cf.getDefaultTranscoder());
 		setUseNagleAlgorithm(cf.useNagleAlgorithm());
     }
@@ -239,6 +241,14 @@ public class ConnectionFactoryBuilder {
 		return this;
 	}
 
+	/**
+	 * Set the minimum timeout exception duration threshold
+	 */
+	public ConnectionFactoryBuilder setTimeoutExceptionDurationThreshold(long to) {
+		timeoutExceptionDurationThreshold = to;
+		return this;
+	}
+
     public Config getVBucketConfig() {
         return vBucketConfig;
     }
@@ -360,6 +370,11 @@ public class ConnectionFactoryBuilder {
 			@Override
 			public int getTimeoutExceptionThreshold() {
 				return timeoutExceptionThreshold;
+			}
+
+			@Override
+			public long getTimeoutExceptionDurationThreshold() {
+				return timeoutExceptionDurationThreshold;
 			}
 
 		};

--- a/src/main/java/net/spy/memcached/DefaultConnectionFactory.java
+++ b/src/main/java/net/spy/memcached/DefaultConnectionFactory.java
@@ -83,6 +83,11 @@ public class DefaultConnectionFactory extends SpyObject
      */
     public static final int DEFAULT_MAX_TIMEOUTEXCEPTION_THRESHOLD = 998;
 
+    /**
+     * Minimum number of millis of continuous timeout exceptions before shutting down a connection
+     */
+    public static final long DEFAULT_MAX_TIMEOUTEXCEPTION_DURATION_THRESHOLD = 30000;
+
 	private final int opQueueLen;
 	private final int readBufSize;
 	private final HashAlgorithm hashAlg;
@@ -286,6 +291,13 @@ public class DefaultConnectionFactory extends SpyObject
 	 */
 	public int getTimeoutExceptionThreshold() {
 		return DEFAULT_MAX_TIMEOUTEXCEPTION_THRESHOLD;
+	}
+
+	/* (non-Javadoc)
+	 * @see net.spy.memcached.ConnectionFactory#getTimeoutExceptionDurationThreshold()
+	 */
+	public long getTimeoutExceptionDurationThreshold() {
+		return DEFAULT_MAX_TIMEOUTEXCEPTION_DURATION_THRESHOLD;
 	}
 
 	protected String getName() {

--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -284,10 +284,7 @@ public final class MemcachedConnection extends SpyObject implements Reconfigurab
 		// see if any connections blew up with large number of timeouts
 		for(SelectionKey sk : selector.keys()) {
 			MemcachedNode mn = (MemcachedNode)sk.attachment();
-			if (mn.getContinuousTimeout() > timeoutExceptionThreshold &&
-					(System.nanoTime() - mn.getContinuousTimeoutStart())/1000000 > timeoutExceptionDurationThreshold)
-			{
-				getLogger().warn("%s exceeded continuous timeout threshold: %d consecutive timeouts over %dms", sk, mn.getContinuousTimeout(), (System.nanoTime() - mn.getContinuousTimeoutStart())/1000000);
+			if (mn.hasExceededContinuousTimeoutThresholds(timeoutExceptionThreshold, timeoutExceptionDurationThreshold)) {
 				lostConnection(mn);
 			}
 		}

--- a/src/main/java/net/spy/memcached/MemcachedNode.java
+++ b/src/main/java/net/spy/memcached/MemcachedNode.java
@@ -202,6 +202,5 @@ public interface MemcachedNode {
 	 */
 	void setContinuousTimeout(boolean timedOut);
 
-	int getContinuousTimeout();
-	long getContinuousTimeoutStart();
+	boolean hasExceededContinuousTimeoutThresholds(int countThreshold, long durationThreshold);
 }

--- a/src/main/java/net/spy/memcached/MemcachedNode.java
+++ b/src/main/java/net/spy/memcached/MemcachedNode.java
@@ -203,4 +203,5 @@ public interface MemcachedNode {
 	void setContinuousTimeout(boolean timedOut);
 
 	int getContinuousTimeout();
+	long getContinuousTimeoutStart();
 }

--- a/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
+++ b/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
@@ -158,6 +158,10 @@ class MemcachedNodeROImpl implements MemcachedNode {
 		throw new UnsupportedOperationException();
 	}
 
+	public long getContinuousTimeoutStart() {
+		throw new UnsupportedOperationException();
+	}
+
 	public void setContinuousTimeout(boolean isIncrease) {
 		throw new UnsupportedOperationException();
 	}

--- a/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
+++ b/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
@@ -154,11 +154,7 @@ class MemcachedNodeROImpl implements MemcachedNode {
 		throw new UnsupportedOperationException();
 	}
 
-	public int getContinuousTimeout() {
-		throw new UnsupportedOperationException();
-	}
-
-	public long getContinuousTimeoutStart() {
+	public boolean hasExceededContinuousTimeoutThresholds(int countThreshold, long durationThreshold) {
 		throw new UnsupportedOperationException();
 	}
 

--- a/src/test/java/net/spy/memcached/MockMemcachedNode.java
+++ b/src/test/java/net/spy/memcached/MockMemcachedNode.java
@@ -115,6 +115,10 @@ public class MockMemcachedNode implements MemcachedNode {
 		return 0;
 	}
 
+	public long getContinuousTimeoutStart() {
+		return 0;
+	}
+
 	public void setContinuousTimeout(boolean timedOut) {
 		// noop
 	}

--- a/src/test/java/net/spy/memcached/MockMemcachedNode.java
+++ b/src/test/java/net/spy/memcached/MockMemcachedNode.java
@@ -111,12 +111,8 @@ public class MockMemcachedNode implements MemcachedNode {
 		// noop
 	}
 
-	public int getContinuousTimeout() {
-		return 0;
-	}
-
-	public long getContinuousTimeoutStart() {
-		return 0;
+	public boolean hasExceededContinuousTimeoutThresholds(int countThreshold, long durationThreshold) {
+		return false;
 	}
 
 	public void setContinuousTimeout(boolean timedOut) {

--- a/src/test/java/net/spy/memcached/ProtocolBaseCase.java
+++ b/src/test/java/net/spy/memcached/ProtocolBaseCase.java
@@ -644,7 +644,6 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
 		    System.err.println("Is active? " + node.isActive());
 		    System.err.println("Has read operation? " + node.hasReadOp() + " Has write operation? " + node.hasWriteOp());
 		try {
-		    System.err.println("Has timed out this many times: " + node.getContinuousTimeout());
 		    System.err.println("Write op: " + node.getCurrentWriteOp());
 		    System.err.println("Read op: " + node.getCurrentReadOp());
 		} catch (UnsupportedOperationException e) {

--- a/src/test/java/net/spy/memcached/vbucket/MemcachedNodeMockImpl.java
+++ b/src/test/java/net/spy/memcached/vbucket/MemcachedNodeMockImpl.java
@@ -49,6 +49,10 @@ public class MemcachedNodeMockImpl implements MemcachedNode {
         return 0;
     }
 
+    public long getContinuousTimeoutStart() {
+        return 0;
+    }
+
     public Operation getCurrentReadOp() {
         return null;
     }

--- a/src/test/java/net/spy/memcached/vbucket/MemcachedNodeMockImpl.java
+++ b/src/test/java/net/spy/memcached/vbucket/MemcachedNodeMockImpl.java
@@ -45,12 +45,8 @@ public class MemcachedNodeMockImpl implements MemcachedNode {
         return null;
     }
 
-    public int getContinuousTimeout() {
-        return 0;
-    }
-
-    public long getContinuousTimeoutStart() {
-        return 0;
+    public boolean hasExceededContinuousTimeoutThresholds(int countThreshold, long durationThreshold) {
+        return false;
     }
 
     public Operation getCurrentReadOp() {


### PR DESCRIPTION
Currently the spymemcached drivers will detect a lost memcached server in two ways. Both methods appear too slow in practice.

After 996 consecutive timed out memcached calls will trigger a server as lost. The timeout is 1s, so a delay is built in depending on the concurrency. This method of detection will take more or less time depending on the particular traffic profile of the application. Unfortunately even our most highly trafficked service capiweb takes several minutes [to detect failure.](https://hubspot.tv.appneta.com/app/ContactsApiWeb/app_server/visualize#fs=1402992720&fe=1402996320&v=heatmap&xpd=1353390&ts=1402994400000&te=1402994640000&nd=912508&xd=1151943)

The second method of detection is a bit fuzzy and may only exist as an artifact of testing. During functional testing on my laptop/aws with iptables used to simulate a failure, the lost server is detected in 20-40s. This method of detection has not been seen in and environment with real traffic such as qa or production. Even in qa when iptables has been used to simulate failure, the failed server is not detected for several minutes. This implies that load is a factor. Again I will stress the unknown and that we really haven't done many tests yet in qa/prod, so the data is very sparse.

This PR introduces detection determinism based upon the clock. With this PR we can configure a memcached pool to detect a host as failed after X consecutive timed out requests (eg 50) over N millis (eg 30sec). The goal is to detect a memcached failure in a deterministic time period (eg 30s).

As for the code changes themselves, the particular angle taken is one of eventual consistency. The sync aspects are not at all exact, there is leeway for things to be missed immediately, but eventually they will be picked up correctly. To say it more clearly in prose, it's entirely possible that exactness will be missed and detection will happen ms to sec later than it could have. That is deemed an acceptable improvement over the current state of the drivers. In particular I'm referring to TCPMemcachedNodeImpl.continuousTimeout and TCPMemcachedNodeImpl.continuousTimeoutStart being synchronized separately.

Our version of the drivers are 3yrs out of date, the up to date version does not have similar functionality. Its feasible that if this code proves useful that we could submit a PR.

@HiJon89 @axiak @marlier @mjball @wsorenson @jaredstehler 
