### PR TITLE
Synchronous incr/decr calls will now update the internal statistics

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedClient.java
+++ b/src/main/java/net/spy/memcached/MemcachedClient.java
@@ -1625,8 +1625,9 @@ public class MemcachedClient extends SpyThread
 				throw new OperationTimeoutException(
 					"Mutate operation timed out, unable to modify counter ["
 						+ key + "]");
+			} else {
+				MemcachedConnection.opSucceeded(op);
 			}
-			MemcachedConnection.opSucceeded(op);
 		} catch (InterruptedException e) {
 			throw new RuntimeException("Interrupted", e);
 		}

--- a/src/main/java/net/spy/memcached/MemcachedClient.java
+++ b/src/main/java/net/spy/memcached/MemcachedClient.java
@@ -1608,7 +1608,7 @@ public class MemcachedClient extends SpyThread
 	private long mutate(Mutator m, String key, int by, long def, int exp) {
 		final AtomicLong rv=new AtomicLong();
 		final CountDownLatch latch=new CountDownLatch(1);
-		addOp(key, opFact.mutate(m, key, by, def, exp, new OperationCallback() {
+		final Operation op = opFact.mutate(m, key, by, def, exp, new OperationCallback() {
 					public void receivedStatus(OperationStatus s) {
 						// XXX:  Potential abstraction leak.
 						// The handling of incr/decr in the binary protocol
@@ -1617,13 +1617,16 @@ public class MemcachedClient extends SpyThread
 					}
 					public void complete() {
 						latch.countDown();
-					}}));
+					}});
+		addOp(key, op);
 		try {
 			if (!latch.await(operationTimeout, TimeUnit.MILLISECONDS)) {
+				MemcachedConnection.opTimedOut(op);
 				throw new OperationTimeoutException(
 					"Mutate operation timed out, unable to modify counter ["
 						+ key + "]");
 			}
+			MemcachedConnection.opSucceeded(op);
 		} catch (InterruptedException e) {
 			throw new RuntimeException("Interrupted", e);
 		}

--- a/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
@@ -44,7 +44,7 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject
 	private ArrayList<Operation> reconnectBlocked;
 	private long defaultOpTimeout;
 
-	// operation Future.get timeout counter
+	// operation Future.(get|mutate) timeout counter
 	private final Object continuousTimeoutLock = new Object();
 	private int continuousTimeout = 0;
 	private long continuousTimeoutStart = 0;


### PR DESCRIPTION
Synchronous incr/decr calls will now update the internal statistics spymemcached uses to determine a remote memcached node is timing out, and thus unavailable. This change is particularly aimed at JavaRateLimiter classes that do not use the regular memcached pool, but instead use the pool with FailureMode.Redistribute. With nothing else using the FailureMode.Redistribute pool, a timing out memcached node would never be pulled from the active duty and would not only time out continuously, but would never fulfill the FailureMode.Redistribute trait of failing over to an available node.

This failure condition is only for memcached nodes that continuously time out, such as our most common memcached failure situation in which an AWS instance just disappears into a black hole. Connections to that server continually time out until a developer forces the instance to reboot or replaces the instance.

To further clarify spymemcached driver behavior, the internal timeout statistics are a different mechanism of failure detection than the simple 'connection refused' situation such as a memcached process stopping/crashing. Situations in which the network layer knows the process is down (ie connection refused) currently act as desired.

@jdwyah @sit @axiak @HiJon89 
