### PR TITLE
The continuous timeout lock member should be declared final

### DIFF
--- a/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
@@ -45,7 +45,7 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject
 	private long defaultOpTimeout;
 
 	// operation Future.get timeout counter
-	private Object continuousTimeoutLock = new Object();
+	private final Object continuousTimeoutLock = new Object();
 	private int continuousTimeout = 0;
 	private long continuousTimeoutStart = 0;
 


### PR DESCRIPTION
The member field created a PR or two ago should have been declared final.

@sit @axiak @HiJon89 @jdwyah
