### PR TITLE
Expose the input queue size

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>net.spy</groupId>
     <artifactId>spymemcached</artifactId>
-    <version>2.12.1-hs-1</version> <!-- used for development -->
+    <version>2.12.1-hs-3</version> <!-- used for development -->
 
     <name>Spymemcached</name>
     <description>A client library for memcached.</description>

--- a/src/main/java/net/spy/memcached/MemcachedNode.java
+++ b/src/main/java/net/spy/memcached/MemcachedNode.java
@@ -248,4 +248,10 @@ public interface MemcachedNode {
 	MemcachedConnection getConnection();
 
 	void setConnection(MemcachedConnection connection);
+
+	/**
+	 * The size of the input operations that are in a pending state
+	 * waiting to be picked up by the event loop.
+	 */
+	int pendingOperationQueueSize();
 }

--- a/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
+++ b/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
@@ -182,6 +182,11 @@ public class MemcachedNodeROImpl implements MemcachedNode {
     throw new UnsupportedOperationException();
   }
 
+  @Override
+  public int pendingOperationQueueSize() {
+    return root.pendingOperationQueueSize();
+  }
+
   public boolean isAuthenticated() {
     throw new UnsupportedOperationException();
   }

--- a/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
@@ -604,6 +604,15 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject implements
     }
   }
 
+  /*
+  * (non-Javadoc)
+  *
+  * @see net.spy.memcached.MemcachedNode#pendingOperationQueueSize
+  */
+  public int pendingOperationQueueSize() {
+    return inputQueue.size();
+  }
+
   private void setContinuousTimeoutStatistics() {
     synchronized (timeoutLock) {
       if (++continuousTimeout == 1) {

--- a/src/test/java/net/spy/memcached/MockMemcachedNode.java
+++ b/src/test/java/net/spy/memcached/MockMemcachedNode.java
@@ -224,4 +224,8 @@ public class MockMemcachedNode implements MemcachedNode {
 
 	}
 
+	@Override
+	public int pendingOperationQueueSize() {
+		return 0;
+	}
 }


### PR DESCRIPTION
When debugging performance of memcached, it would be useful
to know on the client side how many operations are in a waiting
state. Right now unless you parse the `toString()` value of the
underlying `MemcachedNode` implementation, this is impossible
to figure out.

---

@eabbott @prior 
