### PR TITLE
Make these metrics per-node

### DIFF
--- a/src/main/java/net/spy/memcached/metrics/AbstractMetricCollector.java
+++ b/src/main/java/net/spy/memcached/metrics/AbstractMetricCollector.java
@@ -22,10 +22,17 @@
 
 package net.spy.memcached.metrics;
 
+import net.spy.memcached.MemcachedNode;
+
 /**
  * This abstract class implements methods needed by all {@link MetricCollector}s.
  */
 public abstract class AbstractMetricCollector  implements MetricCollector {
+
+  @Override
+  public MetricCollector forNode(MemcachedNode node) {
+    return this;
+  }
 
   @Override
   public void decrementCounter(String name) {

--- a/src/main/java/net/spy/memcached/metrics/MetricCollector.java
+++ b/src/main/java/net/spy/memcached/metrics/MetricCollector.java
@@ -22,6 +22,8 @@
 
 package net.spy.memcached.metrics;
 
+import net.spy.memcached.MemcachedNode;
+
 /**
  * Defines a common API for all {@link MetricCollector}s.
  *
@@ -38,6 +40,8 @@ package net.spy.memcached.metrics;
  * </p>
  */
 public interface MetricCollector {
+
+  MetricCollector forNode(MemcachedNode node);
 
   /**
    * Add a Counter to the collector.

--- a/src/test/java/net/spy/memcached/metrics/DummyMetricCollector.java
+++ b/src/test/java/net/spy/memcached/metrics/DummyMetricCollector.java
@@ -25,6 +25,8 @@ package net.spy.memcached.metrics;
 
 import java.util.HashMap;
 
+import net.spy.memcached.MemcachedNode;
+
 /**
  * A dummy {@link MetricCollector} to measure executions.
  */
@@ -34,6 +36,11 @@ public class DummyMetricCollector implements MetricCollector {
 
   public DummyMetricCollector() {
     metrics = new HashMap<String, Integer>();
+  }
+
+  @Override
+  public MetricCollector forNode(MemcachedNode node) {
+    return this;
   }
 
   @Override


### PR DESCRIPTION
In our metrics collector we can add the node address as a tag and get more granular metrics to see if the memcached slowness affects a single node, multiple nodes, every node, etc.

@axiak @lmikkelsen
