### PR TITLE
Revert "Make these metrics per-node"

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -521,7 +521,7 @@ public class MemcachedConnection extends SpyThread {
     for (MemcachedNode qa : nodesToShutdown) {
       if (!addedQueue.contains(qa)) {
         nodesToShutdown.remove(qa);
-        metrics.forNode(qa).decrementCounter(SHUTD_QUEUE_METRIC);
+        metrics.decrementCounter(SHUTD_QUEUE_METRIC);
         Collection<Operation> notCompletedOperations = qa.destroyInputQueue();
         if (qa.getChannel() != null) {
           qa.getChannel().close();
@@ -804,7 +804,7 @@ public class MemcachedConnection extends SpyThread {
     boolean canWriteMore = node.getBytesRemainingToWrite() > 0;
     while (canWriteMore) {
       int wrote = node.writeSome();
-      metrics.forNode(node).updateHistogram(OVERALL_AVG_BYTES_WRITE_METRIC, wrote);
+      metrics.updateHistogram(OVERALL_AVG_BYTES_WRITE_METRIC, wrote);
       node.fillWriteBuffer(shouldOptimize);
       canWriteMore = wrote > 0 && node.getBytesRemainingToWrite() > 0;
     }
@@ -826,7 +826,7 @@ public class MemcachedConnection extends SpyThread {
     ByteBuffer rbuf = node.getRbuf();
     final SocketChannel channel = node.getChannel();
     int read = channel.read(rbuf);
-    metrics.forNode(node).updateHistogram(OVERALL_AVG_BYTES_READ_METRIC, read);
+    metrics.updateHistogram(OVERALL_AVG_BYTES_READ_METRIC, read);
     if (read < 0) {
       currentOp = handleReadsWhenChannelEndOfStream(currentOp, node, rbuf);
     }
@@ -841,9 +841,9 @@ public class MemcachedConnection extends SpyThread {
 
         long timeOnWire =
             System.nanoTime() - currentOp.getWriteCompleteTimestamp();
-        metrics.forNode(node).updateHistogram(OVERALL_AVG_TIME_ON_WIRE_METRIC,
+        metrics.updateHistogram(OVERALL_AVG_TIME_ON_WIRE_METRIC,
             (int)(timeOnWire / 1000));
-        metrics.forNode(node).markMeter(OVERALL_RESPONSE_METRIC);
+        metrics.markMeter(OVERALL_RESPONSE_METRIC);
         synchronized(currentOp) {
           readBufferAndLogMetrics(currentOp, rbuf, node);
         }
@@ -875,9 +875,9 @@ public class MemcachedConnection extends SpyThread {
           + op;
 
       if (op.hasErrored()) {
-        metrics.forNode(node).markMeter(OVERALL_RESPONSE_FAIL_METRIC);
+        metrics.markMeter(OVERALL_RESPONSE_FAIL_METRIC);
       } else {
-        metrics.forNode(node).markMeter(OVERALL_RESPONSE_SUCC_METRIC);
+        metrics.markMeter(OVERALL_RESPONSE_SUCC_METRIC);
       }
     } else if (currentOp.getState() == OperationState.RETRY) {
       handleRetryInformation(currentOp.getErrorMsg());
@@ -890,7 +890,7 @@ public class MemcachedConnection extends SpyThread {
           + op;
 
       retryOps.add(currentOp);
-      metrics.forNode(node).markMeter(OVERALL_RESPONSE_RETRY_METRIC);
+      metrics.markMeter(OVERALL_RESPONSE_RETRY_METRIC);
     }
   }
 
@@ -992,7 +992,7 @@ public class MemcachedConnection extends SpyThread {
     }
 
     reconnectQueue.put(reconnectTime, node);
-    metrics.forNode(node).incrementCounter(RECON_QUEUE_METRIC);
+    metrics.incrementCounter(RECON_QUEUE_METRIC);
 
     node.setupResend();
     if (failureMode == FailureMode.Redistribute) {
@@ -1108,7 +1108,7 @@ public class MemcachedConnection extends SpyThread {
     while(i.hasNext()) {
       final MemcachedNode node = i.next();
       i.remove();
-      metrics.forNode(node).decrementCounter(RECON_QUEUE_METRIC);
+      metrics.decrementCounter(RECON_QUEUE_METRIC);
 
       try {
         if (!belongsToCluster(node)) {
@@ -1253,7 +1253,7 @@ public class MemcachedConnection extends SpyThread {
     o.initialize();
     node.insertOp(o);
     addedQueue.offer(node);
-    metrics.forNode(node).markMeter(OVERALL_REQUEST_METRIC);
+    metrics.markMeter(OVERALL_REQUEST_METRIC);
 
     Selector s = selector.wakeup();
     assert s == selector : "Wakeup returned the wrong selector.";
@@ -1275,7 +1275,7 @@ public class MemcachedConnection extends SpyThread {
     o.initialize();
     node.addOp(o);
     addedQueue.offer(node);
-    metrics.forNode(node).markMeter(OVERALL_REQUEST_METRIC);
+    metrics.markMeter(OVERALL_REQUEST_METRIC);
 
     Selector s = selector.wakeup();
     assert s == selector : "Wakeup returned the wrong selector.";
@@ -1320,7 +1320,7 @@ public class MemcachedConnection extends SpyThread {
       node.addOp(op);
       op.setHandlingNode(node);
       addedQueue.offer(node);
-      metrics.forNode(node).markMeter(OVERALL_REQUEST_METRIC);
+      metrics.markMeter(OVERALL_REQUEST_METRIC);
     }
 
     Selector s = selector.wakeup();

--- a/src/main/java/net/spy/memcached/metrics/AbstractMetricCollector.java
+++ b/src/main/java/net/spy/memcached/metrics/AbstractMetricCollector.java
@@ -22,17 +22,10 @@
 
 package net.spy.memcached.metrics;
 
-import net.spy.memcached.MemcachedNode;
-
 /**
  * This abstract class implements methods needed by all {@link MetricCollector}s.
  */
 public abstract class AbstractMetricCollector  implements MetricCollector {
-
-  @Override
-  public MetricCollector forNode(MemcachedNode node) {
-    return this;
-  }
 
   @Override
   public void decrementCounter(String name) {

--- a/src/main/java/net/spy/memcached/metrics/MetricCollector.java
+++ b/src/main/java/net/spy/memcached/metrics/MetricCollector.java
@@ -22,8 +22,6 @@
 
 package net.spy.memcached.metrics;
 
-import net.spy.memcached.MemcachedNode;
-
 /**
  * Defines a common API for all {@link MetricCollector}s.
  *
@@ -40,8 +38,6 @@ import net.spy.memcached.MemcachedNode;
  * </p>
  */
 public interface MetricCollector {
-
-  MetricCollector forNode(MemcachedNode node);
 
   /**
    * Add a Counter to the collector.

--- a/src/test/java/net/spy/memcached/metrics/DummyMetricCollector.java
+++ b/src/test/java/net/spy/memcached/metrics/DummyMetricCollector.java
@@ -25,8 +25,6 @@ package net.spy.memcached.metrics;
 
 import java.util.HashMap;
 
-import net.spy.memcached.MemcachedNode;
-
 /**
  * A dummy {@link MetricCollector} to measure executions.
  */
@@ -36,11 +34,6 @@ public class DummyMetricCollector implements MetricCollector {
 
   public DummyMetricCollector() {
     metrics = new HashMap<String, Integer>();
-  }
-
-  @Override
-  public MetricCollector forNode(MemcachedNode node) {
-    return this;
   }
 
   @Override


### PR DESCRIPTION
Reverts HubSpot/java-memcached-client#8

Per node metrics ended up being too expensive, let's go back to cluster granularity so that we can still get some visibility into memcache usage. 

@jhaber Do I need to up the version for this?