### PR TITLE
Fix timeout leading to queue deadlock.

### DIFF
--- a/.blazar.yaml
+++ b/.blazar.yaml
@@ -1,0 +1,27 @@
+buildDeps:
+  - jdk8
+  - maven3
+
+steps:
+  - description: "Installing ant"
+    commands:
+      - wget https://www.apache.org/dist/ant/binaries/apache-ant-1.10.5-bin.zip
+      - unzip -qq apache-ant-1.10.5-bin.zip
+
+  - description: "Running ant build"
+    commands:
+      - apache-ant-1.10.5/bin/ant
+
+  - description: "Changing POM version"
+    commands:
+      - set-maven-versions --root $WORKSPACE --version "$(if [ $GIT_BRANCH == 2.12.1-hs ]; then echo 2.12.$MODULE_BUILD_NUMBER-hubspot; else echo 2.12.$MODULE_BUILD_NUMBER-hubspot-$GIT_BRANCH; fi)"
+
+  - description: "Uploading JAR to Nexus"
+    commands:
+      - mvn -B
+            org.apache.maven.plugins:maven-deploy-plugin:2.8.2:deploy-file
+            -DrepositoryId=s3
+            -Durl=s3://hubspot-maven-artifacts-prod/releases
+            -DpomFile=pom.xml
+            -Dfile=build/jars/spymemcached-2.11.1.jar
+            -Dsources=build/sources/spymemcached-2.11.1.jar

--- a/.blazar.yaml
+++ b/.blazar.yaml
@@ -23,5 +23,5 @@ steps:
             -DrepositoryId=s3
             -Durl=s3://hubspot-maven-artifacts-prod/releases
             -DpomFile=pom.xml
-            -Dfile=build/jars/spymemcached-2.11.1.jar
-            -Dsources=build/sources/spymemcached-2.11.1.jar
+            -Dfile=build/jars/spymemcached-no-version.jar
+            -Dsources=build/sources/spymemcached-no-version.jar

--- a/pom.xml
+++ b/pom.xml
@@ -12,9 +12,9 @@
     -->
 
     <modelVersion>4.0.0</modelVersion>
-    <groupId>net.spy</groupId>
+    <groupId>spy</groupId>
     <artifactId>spymemcached</artifactId>
-    <version>2.12.1-hs-3</version> <!-- used for development -->
+    <version>2.12.1</version> <!-- used for development -->
 
     <name>Spymemcached</name>
     <description>A client library for memcached.</description>

--- a/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
@@ -296,7 +296,7 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject implements
           getLogger().debug("Not writing cancelled op.");
           Operation cancelledOp = removeCurrentWriteOp();
           assert o == cancelledOp;
-        } else if (o.isTimedOut(defaultOpTimeout)) {
+        } else if (o.isTimedOut() || o.isTimedOut(defaultOpTimeout)) {
           getLogger().debug("Not writing timed out op.");
           Operation timedOutOp = removeCurrentWriteOp();
           assert o == timedOutOp;


### PR DESCRIPTION
There is a nasty bug with spymemcached that [can kill a service](https://github.com/sleyzerzon/spymemcached/issues/166). The suggested solution is to check `isTimedOut()` on the operation before checking `isTimedOut(defaultOpTimeout)` since the latter can throw an unexpected exception that prevents any polling of the queue.