### PR TITLE
Build in Blazar and publish snapshots

### DIFF
--- a/.blazar.yaml
+++ b/.blazar.yaml
@@ -1,0 +1,27 @@
+buildDeps:
+  - jdk8
+  - maven3
+
+steps:
+  - description: "Installing ant"
+    commands:
+      - wget http://apache.mirrors.tds.net/ant/binaries/apache-ant-1.10.7-bin.zip
+      - unzip -qq apache-ant-1.10.7-bin.zip
+
+  - description: "Running ant build"
+    commands:
+      - apache-ant-1.10.7/bin/ant
+
+  - description: "Changing POM version"
+    commands:
+      - set-maven-versions --root $WORKSPACE --version "$(if [ $GIT_BRANCH == 2.12.1-hs ]; then echo 2.12.$MODULE_BUILD_NUMBER-hubspot-SNAPSHOT; else echo 2.12.$MODULE_BUILD_NUMBER-hubspot-$GIT_BRANCH-SNAPSHOT; fi)"
+
+  - description: "Uploading JAR to Nexus"
+    commands:
+      - mvn -B
+            org.apache.maven.plugins:maven-deploy-plugin:2.8.2:deploy-file
+            -DrepositoryId=s3
+            -Durl=s3://hubspot-maven-artifacts-prod/snapshots
+            -DpomFile=pom.xml
+            -Dfile=build/jars/spymemcached-no-version.jar
+            -Dsources=build/sources/spymemcached-no-version.jar

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>net.spy</groupId>
     <artifactId>spymemcached</artifactId>
-    <version>2.12.1-hs-3</version> <!-- used for development -->
+    <version>2.12.1-SNAPSHOT</version> <!-- used for development -->
 
     <name>Spymemcached</name>
     <description>A client library for memcached.</description>


### PR DESCRIPTION
This updates the repo to build on blazar and publish snapshots with the build number in the version.

It's basically a copy of https://github.com/HubSpot/java-memcached-client/pull/11 but for snapshots and with a newer ant version.

@jhaber @axiak @jschlather 
