### PR TITLE
Publish to s3

### DIFF
--- a/.blazar.yaml
+++ b/.blazar.yaml
@@ -20,8 +20,8 @@ steps:
     commands:
       - mvn -B
             org.apache.maven.plugins:maven-deploy-plugin:2.8.2:deploy-file
-            -DrepositoryId=gcs
-            -Durl=gcs://hubspot-maven-artifacts-prod/snapshots
+            -DrepositoryId=hubspot-maven-artifacts-prod
+            -Durl=s3://hubspot-maven-artifacts-prod/artifacts/snapshots
             -DpomFile=pom.xml
             -Dfile=build/jars/spymemcached-no-version.jar
             -Dsources=build/sources/spymemcached-no-version.jar


### PR DESCRIPTION
Publish to s3 rather than GCS

it looks like  `http://apache.mirrors.tds.net/ant/binaries/apache-ant-1.10.11-bin.zip` timeout, but it's unrelated to these changes

@melvin15may 