### PR TITLE
Try setting version override

### DIFF
--- a/.blazar.yaml
+++ b/.blazar.yaml
@@ -1,6 +1,9 @@
 buildpack:
   name: Blazar-Buildpack-Java-prebuilt
 
+env:
+  SET_VERSION_OVERRIDE: 1.0-$GIT_BRANCH-SNAPSHOT
+
 before:
   - description: "Installing ant"
     commands:


### PR DESCRIPTION
The prebuilt buildpack assumes that there could be multiple artifacts in the same repo and produces some pretty unfortunately version numbers on this repo, such as `1.0-spymemcached-2.12.1-2.12.1-hs-SNAPSHOT`. Since we know that there's only one artifact in this case, we can simplify the version number back to the normal scheme