### PR TITLE
Get the TLS handshake working 

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -291,8 +291,8 @@
         destdir="${build.test.classes}"
         debug="${javac.debug}"
         includeantruntime="false"
-        target="1.6"
-        source="1.6">
+        target="11"
+        source="11">
       <classpath>
         <path refid="test.classpath"/>
       </classpath>
@@ -401,8 +401,8 @@
         debug="${javac.debug}"
         deprecation="${javac.deprecation}"
         includeantruntime="false"
-        target="1.6"
-        source="1.6">
+        target="11"
+        source="11">
       <classpath refid="${name}.common.classpath" />
     </javac>
 
@@ -414,8 +414,8 @@
         debug="${javac.debug}"
         deprecation="${javac.deprecation}"
         includeantruntime="false"
-        target="1.6"
-        source="1.6">
+        target="11"
+        source="11">
       <classpath refid="${name}.common.classpath"/>
     </javac>
     <move file="${build.src.dir}/net/spy/memcached/changelog.txt"

--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -247,6 +247,8 @@ public class MemcachedConnection extends SpyThread {
    */
   private final int wakeupDelay;
 
+  private final boolean sslEnabled;
+
   /**
    * Construct a {@link MemcachedConnection}.
    *
@@ -276,6 +278,7 @@ public class MemcachedConnection extends SpyThread {
     listenerExecutorService = f.getListenerExecutorService();
     this.bufSize = bufSize;
     this.connectionFactory = f;
+    this.sslEnabled = f.getSslEnabled();
 
     String verifyAlive = System.getProperty("net.spy.verifyAliveOnConnect");
     if(verifyAlive != null && verifyAlive.equals("true")) {
@@ -742,6 +745,14 @@ public class MemcachedConnection extends SpyThread {
    */
   private void finishConnect(final SelectionKey sk, final MemcachedNode node)
       throws IOException {
+
+    if (sslEnabled) {
+      boolean handshakeResult = node.executeTlsHandshake();
+      if (!handshakeResult) {
+        throw new IOException("TLS Handshake Failed on " + node.getSocketAddress());
+      }
+    }
+
     if (verifyAliveOnConnect) {
       final CountDownLatch latch = new CountDownLatch(1);
       final OperationFuture<Boolean> rv = new OperationFuture<Boolean>("noop",

--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -352,6 +352,7 @@ public class MemcachedConnection extends SpyThread {
       try {
         if (ch.connect(sa)) {
           getLogger().info("Connected to %s immediately", qa);
+          getLogger().info("Notifying node connected after creation");
           connected(qa);
         } else {
           getLogger().info("Added %s to connect queue", qa);
@@ -797,6 +798,7 @@ public class MemcachedConnection extends SpyThread {
       }
     }
 
+    getLogger().info("Notifying node connected from finishConnect()");
     connected(node);
     addedQueue.offer(node);
     if (node.getWbuf().hasRemaining()) {
@@ -1138,6 +1140,7 @@ public class MemcachedConnection extends SpyThread {
           ch.socket().setTcpNoDelay(!connectionFactory.useNagleAlgorithm());
           int ops = 0;
           if (ch.connect(node.getSocketAddress())) {
+            getLogger().info("Notifying node connected after reconnect.");
             connected(node);
             addedQueue.offer(node);
             getLogger().info("Immediately reconnected to %s", node);

--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -352,7 +352,6 @@ public class MemcachedConnection extends SpyThread {
       try {
         if (ch.connect(sa)) {
           getLogger().info("Connected to %s immediately", qa);
-          getLogger().info("Notifying node connected after creation");
           connected(qa);
         } else {
           getLogger().info("Added %s to connect queue", qa);
@@ -798,7 +797,6 @@ public class MemcachedConnection extends SpyThread {
       }
     }
 
-    getLogger().info("Notifying node connected from finishConnect()");
     connected(node);
     addedQueue.offer(node);
     if (node.getWbuf().hasRemaining()) {
@@ -1140,7 +1138,6 @@ public class MemcachedConnection extends SpyThread {
           ch.socket().setTcpNoDelay(!connectionFactory.useNagleAlgorithm());
           int ops = 0;
           if (ch.connect(node.getSocketAddress())) {
-            getLogger().info("Notifying node connected after reconnect.");
             connected(node);
             addedQueue.offer(node);
             getLogger().info("Immediately reconnected to %s", node);

--- a/src/main/java/net/spy/memcached/MemcachedNode.java
+++ b/src/main/java/net/spy/memcached/MemcachedNode.java
@@ -254,4 +254,11 @@ public interface MemcachedNode {
 	 * waiting to be picked up by the event loop.
 	 */
 	int pendingOperationQueueSize();
+
+	/**
+	 * Performs a TLS Handshake with the SSLContext provided by the connection factory
+	 * @return true if the handshake was a success, false otherwise
+	 */
+	public boolean executeTlsHandshake();
+
 }

--- a/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
+++ b/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
@@ -187,6 +187,11 @@ public class MemcachedNodeROImpl implements MemcachedNode {
     return root.pendingOperationQueueSize();
   }
 
+  @Override
+  public boolean executeTlsHandshake() {
+    return root.executeTlsHandshake();
+  }
+
   public boolean isAuthenticated() {
     throw new UnsupportedOperationException();
   }

--- a/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
@@ -746,7 +746,8 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject implements
     }
   }
 
-  private boolean executeTlsHandshake() {
+  @Override
+  public boolean executeTlsHandshake() {
       try {
         return tlsConnectionManager.doHandshake(channel);
       } catch (IOException e) {

--- a/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
@@ -31,6 +31,7 @@ import java.nio.channels.SelectionKey;
 import java.nio.channels.SocketChannel;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -47,6 +48,9 @@ import net.spy.memcached.compat.SpyObject;
 import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.protocol.binary.TapAckOperationImpl;
+import net.spy.memcached.tls.TLSConnectionManager;
+
+import javax.net.ssl.SSLContext;
 
 /**
  * Represents a node with the memcached cluster, along with buffering and
@@ -84,6 +88,10 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject implements
   private int continuousTimeout = 0;
   private long continuousTimeoutStart = 0;
 
+  private final boolean sslEnabled;
+  private final Optional<SSLContext> sslContext;
+  private final TLSConnectionManager tlsConnectionManager;
+
   public TCPMemcachedNodeImpl(SocketAddress sa, SocketChannel c, int bufSize,
                               BlockingQueue<Operation> rq, BlockingQueue<Operation> wq,
                               BlockingQueue<Operation> iq, long opQueueMaxBlockTime,
@@ -98,6 +106,13 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject implements
     socketAddress = sa;
     connectionFactory = fact;
     this.authWaitTime = authWaitTime;
+    this.sslEnabled = fact.getSslEnabled();
+    this.sslContext = fact.getSslContext();
+    if (sslEnabled && sslContext.isEmpty()) {
+      throw new IllegalStateException("SSL Context was empty, but SSL was enabled");
+    }
+    this.tlsConnectionManager = sslEnabled ? new TLSConnectionManager(sslContext.get()) : null;
+
     setChannel(c);
     // Since these buffers are allocated rarely (only on client creation
     // or reconfigure), and are passed to Channel.read() and Channel.write(),
@@ -729,6 +744,15 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject implements
     } else {
       authLatch = new CountDownLatch(0);
     }
+  }
+
+  private boolean executeTlsHandshake() {
+      try {
+        return tlsConnectionManager.doHandshake(channel);
+      } catch (IOException e) {
+        getLogger().error("SSL Handshake Failed", e);
+        return false;
+      }
   }
 
   /**

--- a/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
+++ b/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
@@ -204,4 +204,13 @@ public class TLSConnectionManager implements Closeable {
             }
         }
     }
+
+    public static ArrayList<Byte> extractByteBuffer(ByteBuffer buffer) {
+        ByteBuffer duplicate = buffer.duplicate();
+        ArrayList<Byte> bytes = new ArrayList<>();
+        for(int i = 0; i < duplicate.remaining(); i++) {
+            bytes.add(duplicate.get());
+        }
+        return bytes;
+    }
 }

--- a/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
+++ b/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
@@ -55,7 +55,7 @@ public class TLSConnectionManager implements Closeable {
     }
 
     public boolean doHandshake(SocketChannel socketChannel) throws IOException {
-        LOG.info("%s - Beginning handshake.", socketChannel.getRemoteAddress());
+        LOG.debug("%s - Beginning handshake.", socketChannel.getRemoteAddress());
         try {
             sslEngine.beginHandshake();
             currentSession = sslEngine.getSession();
@@ -65,7 +65,7 @@ public class TLSConnectionManager implements Closeable {
             while (!Thread.currentThread().isInterrupted()
                     && handshakeStatus != HandshakeStatus.FINISHED
                     && handshakeStatus != HandshakeStatus.NOT_HANDSHAKING) {
-                LOG.info("%s - Handshake status: %s", socketChannel.getRemoteAddress(), handshakeStatus.name());
+                LOG.debug("%s - Handshake status: %s", socketChannel.getRemoteAddress(), handshakeStatus.name());
                 switch (handshakeStatus) {
                     case NEED_TASK:
                         // we need to finish these tasks for the handshake to continue

--- a/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
+++ b/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
@@ -65,7 +65,7 @@ public class TLSConnectionManager implements Closeable {
             while (!Thread.currentThread().isInterrupted()
                     && handshakeStatus != HandshakeStatus.FINISHED
                     && handshakeStatus != HandshakeStatus.NOT_HANDSHAKING) {
-                LOG.debug("{} - Handshake status: {}", socketChannel.getRemoteAddress(), handshakeStatus.name());
+                LOG.info("{} - Handshake status: {}", socketChannel.getRemoteAddress(), handshakeStatus.name());
                 switch (handshakeStatus) {
                     case NEED_TASK:
                         // we need to finish these tasks for the handshake to continue

--- a/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
+++ b/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
@@ -65,6 +65,7 @@ public class TLSConnectionManager implements Closeable {
             while (!Thread.currentThread().isInterrupted()
                     && handshakeStatus != HandshakeStatus.FINISHED
                     && handshakeStatus != HandshakeStatus.NOT_HANDSHAKING) {
+                LOG.debug("{} - Handshake status: {}", socketChannel.getRemoteAddress(), handshakeStatus.name());
                 switch (handshakeStatus) {
                     case NEED_TASK:
                         // we need to finish these tasks for the handshake to continue

--- a/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
+++ b/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
@@ -24,7 +24,8 @@ public class TLSConnectionManager implements Closeable {
 
     private static final Logger LOG = LoggerFactory.getLogger(TLSConnectionManager.class);
 
-    private final SSLEngine sslEngine;
+    private final SSLContext sslContext;
+    private SSLEngine sslEngine;
 
     private SSLSession currentSession;
 
@@ -36,13 +37,18 @@ public class TLSConnectionManager implements Closeable {
     ExecutorService executor = Executors.newSingleThreadExecutor();
 
     public TLSConnectionManager(SSLContext sslContext) {
-        this.sslEngine = sslContext.createSSLEngine();
-
-        configureSslEngine();
+        this.sslContext = sslContext;
     }
 
-    private void configureSslEngine() {
+    private void initSSLEngine() {
         // We are the client, not the server
+        if (sslEngine != null) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Resetting SSL Engine");
+            }
+            closeSslEngine();
+        }
+        sslEngine = sslContext.createSSLEngine();
         sslEngine.setUseClientMode(true);
     }
 
@@ -55,17 +61,24 @@ public class TLSConnectionManager implements Closeable {
     }
 
     public boolean doHandshake(SocketChannel socketChannel) throws IOException {
-        LOG.debug("%s - Beginning handshake.", socketChannel.getRemoteAddress());
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("%s - Beginning handshake.", socketChannel.getRemoteAddress());
+        }
+
         try {
+            initSSLEngine();
             sslEngine.beginHandshake();
             currentSession = sslEngine.getSession();
             initBuffers(currentSession);
 
             HandshakeStatus handshakeStatus = sslEngine.getHandshakeStatus();
+            if (LOG.isDebugEnabled()) {
+                LOG.info("%s - Handshake status: %s", socketChannel.getRemoteAddress(), handshakeStatus.name());
+            }
             while (!Thread.currentThread().isInterrupted()
                     && handshakeStatus != HandshakeStatus.FINISHED
                     && handshakeStatus != HandshakeStatus.NOT_HANDSHAKING) {
-                LOG.debug("%s - Handshake status: %s", socketChannel.getRemoteAddress(), handshakeStatus.name());
+
                 switch (handshakeStatus) {
                     case NEED_TASK:
                         // we need to finish these tasks for the handshake to continue
@@ -99,7 +112,14 @@ public class TLSConnectionManager implements Closeable {
                                 return false;
                             }
                             // We're done with the handshake, signal that we aren't going to be sending or receiving any more data
-                            sslEngine.closeInbound();
+                            try {
+                                sslEngine.closeInbound();
+                            } catch (SSLException e) {
+                                if (LOG.isDebugEnabled()) {
+                                    // This doesn't seem to be critical, but it could be nice to know about
+                                    LOG.warn("{} - tried to close inbound traffic but has not received a TLS close notification yet due to end of stream.", socketChannel.getRemoteAddress(), e);
+                                }
+                            }
                             sslEngine.closeOutbound();
                             break;
                         }
@@ -118,6 +138,9 @@ public class TLSConnectionManager implements Closeable {
                 }
 
                 handshakeStatus = sslEngine.getHandshakeStatus();
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("%s - Handshake status: %s", socketChannel.getRemoteAddress(), handshakeStatus.name());
+                }
             }
 
             // If we were interrupted, get out
@@ -130,14 +153,29 @@ public class TLSConnectionManager implements Closeable {
         } catch (SSLException | InterruptedException e) {
             throw new RuntimeException("Caught exception during SSL Handshake", e);
         }
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("%s - Handshake complete.", socketChannel.getRemoteAddress());
+        }
         return true;
     }
 
     @Override
     public void close() throws IOException {
+        closeSslEngine();
+    }
+
+    private void closeSslEngine() {
         sslEngine.setEnableSessionCreation(false);
         sslEngine.closeOutbound();
-        sslEngine.closeInbound();
+        try {
+            sslEngine.closeInbound();
+        } catch (SSLException e) {
+            if (LOG.isDebugEnabled()) {
+                // This doesn't seem to be critical, but it could be nice to know about
+                LOG.warn("Tried to close inbound traffic but has not received a TLS close notification yet due to end of stream.", e);
+            }
+        }
+        sslEngine = null;
     }
 
     private void handleHandshakeWrapResult(SocketChannel socketChannel, SSLEngineResult result) throws SSLException {
@@ -189,7 +227,7 @@ public class TLSConnectionManager implements Closeable {
     }
 
     private void sendNetworkBuffer(SocketChannel socketChannel) throws SSLException {
-        networkOutBuffer.flip(); // Change from read to write
+        networkOutBuffer.flip(); // Change from reading to writing
         // Send data over the wire
         while(networkOutBuffer.hasRemaining()) {
             try {
@@ -198,14 +236,5 @@ public class TLSConnectionManager implements Closeable {
                 throw new SSLException("Failed to write wrapped buffer.", e);
             }
         }
-    }
-
-    public static ArrayList<Byte> extractByteBuffer(ByteBuffer buffer) {
-        ByteBuffer duplicate = buffer.duplicate();
-        ArrayList<Byte> bytes = new ArrayList<>();
-        for(int i = 0; i < duplicate.remaining(); i++) {
-            bytes.add(duplicate.get());
-        }
-        return bytes;
     }
 }

--- a/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
+++ b/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
@@ -99,8 +99,8 @@ public class TLSConnectionManager implements Closeable {
                                 return false;
                             }
                             // We're done with the handshake, signal that we aren't going to be sending or receiving any more data
-                            sslEngine.closeInbound();
                             sslEngine.closeOutbound();
+                            sslEngine.closeInbound();
                             break;
                         }
                         networkInBuffer.flip();

--- a/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
+++ b/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
@@ -1,0 +1,198 @@
+package net.spy.memcached.tls;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLEngineResult;
+import javax.net.ssl.SSLEngineResult.HandshakeStatus;
+import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLSession;
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.SocketChannel;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+public class TLSConnectionManager implements Closeable {
+
+    private final SSLContext sslContext;
+    private final SSLEngine sslEngine;
+
+    private SSLSession currentSession;
+
+    private ByteBuffer appOutBuffer; // Holds the data we are preparing to send out
+    private ByteBuffer appInBuffer; // Holds the data we have received and unwrapped
+    private ByteBuffer networkOutBuffer; // Holds the data we are sending across the wire
+    private ByteBuffer networkInBuffer; // Holds the data we have received from the wire
+
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+
+    public TLSConnectionManager(SSLContext sslContext) {
+        this.sslContext = sslContext;
+        this.sslEngine = sslContext.createSSLEngine();
+
+        configureSslEngine();
+    }
+
+    private void configureSslEngine() {
+        // We are the client, not the server
+        sslEngine.setUseClientMode(true);
+    }
+
+    private void initBuffers(SSLSession session) {
+        // allocateDirect() to keep all bytes contiguous in memory
+        appOutBuffer = ByteBuffer.allocateDirect(session.getApplicationBufferSize());
+        appInBuffer = ByteBuffer.allocateDirect(session.getApplicationBufferSize());
+        networkOutBuffer = ByteBuffer.allocateDirect(session.getPacketBufferSize());
+        networkInBuffer = ByteBuffer.allocateDirect(session.getPacketBufferSize());
+    }
+
+    public boolean doHandshake(SocketChannel socketChannel) throws IOException {
+
+        try {
+            sslEngine.beginHandshake();
+            currentSession = sslEngine.getHandshakeSession();
+            initBuffers(currentSession);
+
+            HandshakeStatus handshakeStatus = sslEngine.getHandshakeStatus();
+            while (!Thread.currentThread().isInterrupted()
+                    && handshakeStatus != HandshakeStatus.FINISHED
+                    && handshakeStatus != HandshakeStatus.NOT_HANDSHAKING) {
+                switch (handshakeStatus) {
+                    case NEED_TASK:
+                        // we need to finish these tasks for the handshake to continue
+                        List<Future<?>> tasks = new ArrayList<>();
+                        Runnable currentTask = sslEngine.getDelegatedTask();
+                        while(currentTask != null) {
+                            tasks.add(executor.submit(currentTask));
+                            currentTask = sslEngine.getDelegatedTask();
+                        }
+                        for (Future<?> task : tasks) {
+                            try {
+                                task.get();
+                            } catch (ExecutionException e) {
+                                // TODO make this more clear
+                                throw new RuntimeException(e);
+                            }
+                        }
+                        break;
+                    case NEED_WRAP:
+                        // We're about to send something to the server, but it needs to be wrapped first
+                        networkOutBuffer.clear();
+                        SSLEngineResult wrapResult = sslEngine.wrap(appOutBuffer, networkOutBuffer);
+                        handleHandshakeWrapResult(socketChannel, wrapResult);
+                        break;
+                    case NEED_UNWRAP:
+                        // We need to receive a message from the server, but it needs to be unwrapped first
+                        if (socketChannel.read(networkInBuffer) < 0) {
+                            // The message was empty
+                            if (sslEngine.isInboundDone() && sslEngine.isOutboundDone()) {
+                                // SSL Engine closed before handshake could complete
+                                return false;
+                            }
+                            // We're done with the handshake, signal that we aren't going to be sending or receiving any more data
+                            sslEngine.closeInbound();
+                            sslEngine.closeOutbound();
+                            break;
+                        }
+                        networkOutBuffer.flip();
+                        SSLEngineResult unwrapResult = sslEngine.unwrap(networkInBuffer, appInBuffer);
+                        networkOutBuffer.compact(); // Leaves any unread bytes while creating more room in the buffer
+                        if (unwrapResult.getStatus() == SSLEngineResult.Status.CLOSED) {
+                            return false; // Server closed session before handshake completed
+                        }
+                        handleHandshakeUnwrapResult(socketChannel, unwrapResult);
+                        break;
+                    case NEED_UNWRAP_AGAIN:
+                        throw new UnsupportedOperationException("DTLS not supported");
+                    default:
+                        throw new IllegalStateException("Invalid SSL status: " + handshakeStatus);
+                }
+
+                handshakeStatus = sslEngine.getHandshakeStatus();
+            }
+
+            // If we were interrupted, get out
+            if (Thread.currentThread().isInterrupted()) {
+                this.close();
+                throw new InterruptedException("Thread interrupted while completing SSL Handshake");
+            }
+
+
+        } catch (SSLException | InterruptedException e) {
+            throw new RuntimeException("Caught exception during SSL Handshake", e);
+        }
+        return true;
+    }
+
+    @Override
+    public void close() throws IOException {
+        sslEngine.setEnableSessionCreation(false);
+        sslEngine.closeOutbound();
+        sslEngine.closeInbound();
+    }
+
+    private void handleHandshakeWrapResult(SocketChannel socketChannel, SSLEngineResult result) throws SSLException {
+        switch (result.getStatus()) {
+            case BUFFER_UNDERFLOW:
+                // We should not get here
+                throw new SSLException("Buffer underflow occurred after wrap");
+            case BUFFER_OVERFLOW:
+                // If networkOutBuffer is too small to contain the response
+                networkOutBuffer = enlargeBuffer(networkOutBuffer, sslEngine.getSession().getPacketBufferSize());
+                // Try again with new larger buffer
+                break;
+            case OK:
+                sendNetworkBuffer(socketChannel);
+                break;
+            case CLOSED:
+                // We need to tell the server we're closing
+                sendNetworkBuffer(socketChannel);
+                // The next status will be NEED_UNWRAP and we'll need to pre-emptively clear the input network data
+                networkInBuffer.clear();
+                break;
+        }
+    }
+
+    private void handleHandshakeUnwrapResult(SocketChannel socketChannel, SSLEngineResult result) throws SSLException {
+        switch (result.getStatus()) {
+            case BUFFER_UNDERFLOW:
+                // If the network buffer is too small
+                networkInBuffer = enlargeBuffer(networkInBuffer, sslEngine.getSession().getPacketBufferSize());
+                break;
+            case BUFFER_OVERFLOW:
+                // if networkInBuffer is larger than appInBuffer
+                appInBuffer = enlargeBuffer(appInBuffer, sslEngine.getSession().getApplicationBufferSize());
+                // try again with larger buffer
+                break;
+            case OK:
+            case CLOSED:
+                break;
+        }
+    }
+
+    private static ByteBuffer enlargeBuffer(ByteBuffer buffer, int suggestedCapacity) {
+        if (suggestedCapacity > buffer.capacity()) {
+            return ByteBuffer.allocate(suggestedCapacity);
+        } else {
+            // If the suggested capacity is still too small, double the size
+            return ByteBuffer.allocate(buffer.capacity() * 2);
+        }
+    }
+
+    private void sendNetworkBuffer(SocketChannel socketChannel) throws SSLException {
+        networkOutBuffer.flip(); // Change from read to write
+        // Send data over the wire
+        while(networkOutBuffer.hasRemaining()) {
+            try {
+                socketChannel.write(networkOutBuffer);
+            } catch (IOException e) {
+                throw new SSLException("Failed to write wrapped buffer.", e);
+            }
+        }
+    }
+}

--- a/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
+++ b/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
@@ -104,6 +104,11 @@ public class TLSConnectionManager implements Closeable {
                             break;
                         }
                         networkOutBuffer.flip();
+                        ByteBuffer bufferContent = networkOutBuffer.duplicate();
+                        ArrayList<Byte> bytes = new ArrayList<>();
+                        for(int i = 0; i < bufferContent.remaining(); i++) {
+                            bufferContent.put(bufferContent.get());
+                        }
                         SSLEngineResult unwrapResult = sslEngine.unwrap(networkInBuffer, appInBuffer);
                         networkOutBuffer.compact(); // Leaves any unread bytes while creating more room in the buffer
                         if (unwrapResult.getStatus() == SSLEngineResult.Status.CLOSED) {

--- a/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
+++ b/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
@@ -58,7 +58,7 @@ public class TLSConnectionManager implements Closeable {
         LOG.info("{} - Beginning handshake.", socketChannel.getRemoteAddress());
         try {
             sslEngine.beginHandshake();
-            currentSession = sslEngine.getHandshakeSession();
+            currentSession = sslEngine.getSession();
             initBuffers(currentSession);
 
             HandshakeStatus handshakeStatus = sslEngine.getHandshakeStatus();

--- a/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
+++ b/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
@@ -16,8 +16,6 @@ import java.nio.channels.SocketChannel;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 public class TLSConnectionManager implements Closeable {
@@ -33,8 +31,6 @@ public class TLSConnectionManager implements Closeable {
     private ByteBuffer appInBuffer; // Holds the data we have received and unwrapped
     private ByteBuffer networkOutBuffer; // Holds the data we are sending across the wire
     private ByteBuffer networkInBuffer; // Holds the data we have received from the wire
-
-    ExecutorService executor = Executors.newSingleThreadExecutor();
 
     public TLSConnectionManager(SSLContext sslContext) {
         this.sslContext = sslContext;
@@ -82,19 +78,14 @@ public class TLSConnectionManager implements Closeable {
                 switch (handshakeStatus) {
                     case NEED_TASK:
                         // we need to finish these tasks for the handshake to continue
-                        List<Future<?>> tasks = new ArrayList<>();
+                        List<Runnable> tasks = new ArrayList<>();
                         Runnable currentTask = sslEngine.getDelegatedTask();
                         while(currentTask != null) {
-                            tasks.add(executor.submit(currentTask));
+                            tasks.add(currentTask);
                             currentTask = sslEngine.getDelegatedTask();
                         }
-                        for (Future<?> task : tasks) {
-                            try {
-                                task.get();
-                            } catch (ExecutionException e) {
-                                // TODO make this more clear
-                                throw new RuntimeException(e);
-                            }
+                        for (Runnable task : tasks) {
+                            task.run();
                         }
                         break;
                     case NEED_WRAP:

--- a/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
+++ b/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
@@ -1,5 +1,8 @@
 package net.spy.memcached.tls;
 
+import net.spy.memcached.compat.log.Logger;
+import net.spy.memcached.compat.log.LoggerFactory;
+
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLEngineResult;
@@ -19,7 +22,8 @@ import java.util.concurrent.Future;
 
 public class TLSConnectionManager implements Closeable {
 
-    private final SSLContext sslContext;
+    private static final Logger LOG = LoggerFactory.getLogger(TLSConnectionManager.class);
+
     private final SSLEngine sslEngine;
 
     private SSLSession currentSession;
@@ -32,7 +36,6 @@ public class TLSConnectionManager implements Closeable {
     ExecutorService executor = Executors.newSingleThreadExecutor();
 
     public TLSConnectionManager(SSLContext sslContext) {
-        this.sslContext = sslContext;
         this.sslEngine = sslContext.createSSLEngine();
 
         configureSslEngine();
@@ -52,7 +55,7 @@ public class TLSConnectionManager implements Closeable {
     }
 
     public boolean doHandshake(SocketChannel socketChannel) throws IOException {
-
+        LOG.info("{} - Beginning handshake.", socketChannel.getRemoteAddress());
         try {
             sslEngine.beginHandshake();
             currentSession = sslEngine.getHandshakeSession();

--- a/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
+++ b/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
@@ -99,8 +99,8 @@ public class TLSConnectionManager implements Closeable {
                                 return false;
                             }
                             // We're done with the handshake, signal that we aren't going to be sending or receiving any more data
-                            sslEngine.closeOutbound();
                             sslEngine.closeInbound();
+                            sslEngine.closeOutbound();
                             break;
                         }
                         networkInBuffer.flip();

--- a/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
+++ b/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
@@ -107,7 +107,7 @@ public class TLSConnectionManager implements Closeable {
                         ByteBuffer bufferContent = networkOutBuffer.duplicate();
                         ArrayList<Byte> bytes = new ArrayList<>();
                         for(int i = 0; i < bufferContent.remaining(); i++) {
-                            bufferContent.put(bufferContent.get());
+                            bytes.add(bufferContent.get());
                         }
                         SSLEngineResult unwrapResult = sslEngine.unwrap(networkInBuffer, appInBuffer);
                         networkOutBuffer.compact(); // Leaves any unread bytes while creating more room in the buffer

--- a/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
+++ b/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
@@ -55,7 +55,7 @@ public class TLSConnectionManager implements Closeable {
     }
 
     public boolean doHandshake(SocketChannel socketChannel) throws IOException {
-        LOG.info("{} - Beginning handshake.", socketChannel.getRemoteAddress());
+        LOG.info("%s - Beginning handshake.", socketChannel.getRemoteAddress());
         try {
             sslEngine.beginHandshake();
             currentSession = sslEngine.getSession();
@@ -65,7 +65,7 @@ public class TLSConnectionManager implements Closeable {
             while (!Thread.currentThread().isInterrupted()
                     && handshakeStatus != HandshakeStatus.FINISHED
                     && handshakeStatus != HandshakeStatus.NOT_HANDSHAKING) {
-                LOG.info("{} - Handshake status: {}", socketChannel.getRemoteAddress(), handshakeStatus.name());
+                LOG.info("%s - Handshake status: %s", socketChannel.getRemoteAddress(), handshakeStatus.name());
                 switch (handshakeStatus) {
                     case NEED_TASK:
                         // we need to finish these tasks for the handshake to continue

--- a/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
+++ b/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
@@ -103,14 +103,9 @@ public class TLSConnectionManager implements Closeable {
                             sslEngine.closeOutbound();
                             break;
                         }
-                        networkOutBuffer.flip();
-                        ByteBuffer bufferContent = networkOutBuffer.duplicate();
-                        ArrayList<Byte> bytes = new ArrayList<>();
-                        for(int i = 0; i < bufferContent.remaining(); i++) {
-                            bytes.add(bufferContent.get());
-                        }
+                        networkInBuffer.flip();
                         SSLEngineResult unwrapResult = sslEngine.unwrap(networkInBuffer, appInBuffer);
-                        networkOutBuffer.compact(); // Leaves any unread bytes while creating more room in the buffer
+                        networkInBuffer.compact(); // Leaves any unread bytes while creating more room in the buffer
                         if (unwrapResult.getStatus() == SSLEngineResult.Status.CLOSED) {
                             return false; // Server closed session before handshake completed
                         }

--- a/src/test/java/net/spy/memcached/MockMemcachedNode.java
+++ b/src/test/java/net/spy/memcached/MockMemcachedNode.java
@@ -228,4 +228,9 @@ public class MockMemcachedNode implements MemcachedNode {
 	public int pendingOperationQueueSize() {
 		return 0;
 	}
+
+	@Override
+	public boolean executeTlsHandshake() {
+		return true;
+	}
 }


### PR DESCRIPTION
Requesting review on this PR into our feature branch for enabling TLS support. This PR executes the SSL Handshake and does nothing else. I tested this against a HubSpot hosted Memcached cluster with 1.6.28 running and the following command: 

```
memcached -Z -v -o ssl_chain_cert=/path/certificate.pem,ssl_key=/path/key.pem,ssl_ca_cert=/path/ca_chain.pem,ssl_verify_mode=0 -m2048 -c13000 -t1 -I4m -
```

The handshake completes successfully, but the client calls fail since the rest of the SSL implementation has not been completed yet. This implementation will come through in future PRs.