### PR TITLE
Changing the build.xml to use java 11 so that we can use java 11 features

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -291,8 +291,8 @@
         destdir="${build.test.classes}"
         debug="${javac.debug}"
         includeantruntime="false"
-        target="1.6"
-        source="1.6">
+        target="11"
+        source="11">
       <classpath>
         <path refid="test.classpath"/>
       </classpath>
@@ -401,8 +401,8 @@
         debug="${javac.debug}"
         deprecation="${javac.deprecation}"
         includeantruntime="false"
-        target="1.6"
-        source="1.6">
+        target="11"
+        source="11">
       <classpath refid="${name}.common.classpath" />
     </javac>
 
@@ -414,8 +414,8 @@
         debug="${javac.debug}"
         deprecation="${javac.deprecation}"
         includeantruntime="false"
-        target="1.6"
-        source="1.6">
+        target="11"
+        source="11">
       <classpath refid="${name}.common.classpath"/>
     </javac>
     <move file="${build.src.dir}/net/spy/memcached/changelog.txt"


### PR DESCRIPTION
Java 1.6 is over 14 years out of date. For changes we're trying to implement to support TLS, we want to add support for Java 11. Internally at HubSpot we've decided to upgrade our main branch rather than increment the minor version.