### PR TITLE
Adding factory methods for enabling SSL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,18 @@
             scm:git:git://github.com/couchbase/spymemcached.git
         </connection>
     </scm>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>11</source>
+                    <target>11</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
     <developers>
         <developer>
             <id>net.spy.spymemcached</id>

--- a/src/main/java/net/spy/memcached/ConnectionFactory.java
+++ b/src/main/java/net/spy/memcached/ConnectionFactory.java
@@ -29,8 +29,10 @@ import java.net.SocketAddress;
 import java.nio.channels.SocketChannel;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
+import javax.net.ssl.SSLContext;
 
 import net.spy.memcached.auth.AuthDescriptor;
 import net.spy.memcached.metrics.MetricCollector;
@@ -202,4 +204,16 @@ public interface ConnectionFactory {
    * @return the time in milliseconds.
    */
   long getAuthWaitTime();
+
+  /**
+   * If the client connection should be made with SSL
+   * @return true if SSL is enabled
+   */
+  boolean getSslEnabled();
+
+  /**
+   * The SSLContext to perform the handshake with. If sslEnabled is true, this may not be Optional.empty()
+   * @return The SSLContext
+   */
+  Optional<SSLContext> getSslContext();
 }

--- a/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
+++ b/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
@@ -26,6 +26,7 @@ package net.spy.memcached;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
 
@@ -37,6 +38,8 @@ import net.spy.memcached.ops.OperationQueueFactory;
 import net.spy.memcached.protocol.ascii.AsciiOperationFactory;
 import net.spy.memcached.protocol.binary.BinaryOperationFactory;
 import net.spy.memcached.transcoders.Transcoder;
+
+import javax.net.ssl.SSLContext;
 
 /**
  * Builder for more easily configuring a ConnectionFactory.
@@ -82,6 +85,8 @@ public class ConnectionFactoryBuilder {
   protected MetricCollector collector = null;
   protected ExecutorService executorService = null;
   protected long authWaitTime = DefaultConnectionFactory.DEFAULT_AUTH_WAIT_TIME;
+  protected boolean sslEnabled = false;
+  protected Optional<SSLContext> sslContext = Optional.empty();
 
   /**
    * Set the operation queue factory.
@@ -109,6 +114,8 @@ public class ConnectionFactoryBuilder {
     setEnableMetrics(cf.enableMetrics());
     setListenerExecutorService(cf.getListenerExecutorService());
     setAuthWaitTime(cf.getAuthWaitTime());
+    setSslEnabled(cf.getSslEnabled());
+    setSslContext(cf.getSslContext());
   }
 
   public ConnectionFactoryBuilder setOpQueueFactory(OperationQueueFactory q) {
@@ -344,9 +351,37 @@ public class ConnectionFactoryBuilder {
   }
 
   /**
+   * Enable SSL for the client
+   * @param sslEnabled true if the client should use SSL
+   */
+  public ConnectionFactoryBuilder setSslEnabled(boolean sslEnabled) {
+    this.sslEnabled = sslEnabled;
+    return this;
+  }
+
+  /**
+   * Set the desired SSL Context for SSL connections. Ignored if sslEnabled is false
+   * @param sslContext The desired SSL Context
+   */
+  public ConnectionFactoryBuilder setSslContext(SSLContext sslContext) {
+    return this.setSslContext(Optional.ofNullable(sslContext));
+  }
+
+  /**
+   * Set the desired SSL Context for SSL connections. Ignored if sslEnabled is false
+   * @param sslContext The desired SSL Context
+   */
+  public ConnectionFactoryBuilder setSslContext(Optional<SSLContext> sslContext) {
+    this.sslContext = sslContext;
+    return this;
+  }
+
+  /**
    * Get the ConnectionFactory set up with the provided parameters.
    */
   public ConnectionFactory build() {
+    checkPreconditions();
+
     return new DefaultConnectionFactory() {
 
       @Override
@@ -483,6 +518,16 @@ public class ConnectionFactoryBuilder {
       public long getAuthWaitTime() {
         return authWaitTime;
       }
+
+      @Override
+      public boolean getSslEnabled() {
+        return sslEnabled;
+      }
+
+      @Override
+      public Optional<SSLContext> getSslContext() {
+        return sslContext;
+      }
     };
 
   }
@@ -520,5 +565,16 @@ public class ConnectionFactoryBuilder {
      * VBucket support.
      */
     VBUCKET
+  }
+
+  /**
+   * Ensures that the settings are compatible with each other
+   */
+  private void checkPreconditions() {
+    if (sslEnabled && sslContext.isEmpty()) {
+      throw new IllegalArgumentException(
+        "SSL is enabled but SSLContext is empty. Please call .setSslContext() before building."
+      );
+    }
   }
 }

--- a/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
+++ b/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
@@ -31,6 +31,8 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
 
 import net.spy.memcached.auth.AuthDescriptor;
+import net.spy.memcached.compat.log.Logger;
+import net.spy.memcached.compat.log.LoggerFactory;
 import net.spy.memcached.metrics.MetricCollector;
 import net.spy.memcached.metrics.MetricType;
 import net.spy.memcached.ops.Operation;
@@ -46,6 +48,7 @@ import javax.net.ssl.SSLContext;
  */
 public class ConnectionFactoryBuilder {
 
+  protected static final Logger LOG = LoggerFactory.getLogger(ConnectionFactoryBuilder.class);
   protected OperationQueueFactory opQueueFactory;
   protected OperationQueueFactory readQueueFactory;
   protected OperationQueueFactory writeQueueFactory;
@@ -571,10 +574,13 @@ public class ConnectionFactoryBuilder {
    * Ensures that the settings are compatible with each other
    */
   private void checkPreconditions() {
-    if (sslEnabled && sslContext.isEmpty()) {
-      throw new IllegalArgumentException(
-        "SSL is enabled but SSLContext is empty. Please call .setSslContext() before building."
-      );
+    if (sslEnabled) {
+      LOG.error("Memcached ConnectionFactory configured with SSL Enabled, but SSL support is not ready.");
+      if (sslContext.isEmpty()) {
+        throw new IllegalArgumentException(
+                "SSL is enabled but SSLContext is empty. Please call .setSslContext() before building."
+        );
+      }
     }
   }
 }

--- a/src/main/java/net/spy/memcached/DefaultConnectionFactory.java
+++ b/src/main/java/net/spy/memcached/DefaultConnectionFactory.java
@@ -30,12 +30,11 @@ import java.nio.channels.SocketChannel;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -53,6 +52,8 @@ import net.spy.memcached.protocol.binary.BinaryMemcachedNodeImpl;
 import net.spy.memcached.protocol.binary.BinaryOperationFactory;
 import net.spy.memcached.transcoders.SerializingTranscoder;
 import net.spy.memcached.transcoders.Transcoder;
+
+import javax.net.ssl.SSLContext;
 
 /**
  * Default implementation of ConnectionFactory.
@@ -423,6 +424,26 @@ public class DefaultConnectionFactory extends SpyObject implements
    */
   public AuthDescriptor getAuthDescriptor() {
     return null;
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see net.spy.memcached.ConnectionFactory#getSslEnabled();
+   */
+  @Override
+  public boolean getSslEnabled() {
+    return false;
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see net.spy.memcached.ConnectionFactory#getSslContext();
+   */
+  @Override
+  public Optional<SSLContext> getSslContext() {
+    return Optional.empty();
   }
 
   /*


### PR DESCRIPTION
In order to allow clients to use SSL, this PR adds an option to ConnectionFactory that allows the client to specify if the connection should use SSL. If enabled, they can provide an SSLContext which can be used to generate SSLEngines which are used for managing the SSL Connection.

This is an intermediate step to allow us to build out tests that can be configured for SSL.