### PR TITLE
Adding a latch to track successful handshake and blocking in the same places SASL blocks

### DIFF
--- a/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
@@ -37,8 +37,10 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
+
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLException;
+
 import net.jodah.failsafe.CircuitBreaker;
 import net.jodah.failsafe.function.CheckedRunnable;
 import net.spy.memcached.ConnectionFactory;
@@ -426,7 +428,7 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject implements
    */
   public final void addOp(Operation op) {
     try {
-      if (!authLatch.await(authWaitTime, TimeUnit.MILLISECONDS)) {
+      if (!authLatch.await(authWaitTime, TimeUnit.MILLISECONDS) && awaitSslHandshakeMaybe()) {
         FailureMode mode = connectionFactory.getFailureMode();
         if (mode == FailureMode.Redistribute || mode == FailureMode.Retry) {
           getLogger().debug("Redistributing Operation " + op + " because auth "
@@ -544,6 +546,9 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject implements
    * @see net.spy.memcached.MemcachedNode#isAuthenticated()
    */
   public boolean isAuthenticated() {
+    if (sslEnabled) {
+      return tlsConnectionManager.wasHandshakeSuccessful();
+    }
     return (0 == authLatch.getCount());
   }
 
@@ -740,6 +745,7 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject implements
     }
   }
 
+  // Only called for SASL auth
   public final void authComplete() {
     if (reconnectBlocked != null && reconnectBlocked.size() > 0) {
       inputQueue.addAll(reconnectBlocked);
@@ -748,6 +754,9 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject implements
   }
 
   public final void setupForAuth() {
+    if (sslEnabled) {
+      tlsConnectionManager.resetHandshakeStatus();
+    }
     if (shouldAuth) {
       authLatch = new CountDownLatch(1);
       if (inputQueue.size() > 0) {
@@ -769,6 +778,13 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject implements
         getLogger().error("SSL Handshake Failed", e);
         return false;
       }
+  }
+
+  private boolean awaitSslHandshakeMaybe() throws InterruptedException {
+    if (sslEnabled) {
+      return tlsConnectionManager.awaitHandshake(authWaitTime);
+    }
+    return true;
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
+++ b/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
@@ -1,7 +1,13 @@
 package net.spy.memcached.tls;
 
-import net.spy.memcached.compat.log.Logger;
-import net.spy.memcached.compat.log.LoggerFactory;
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.SocketChannel;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
@@ -9,12 +15,9 @@ import javax.net.ssl.SSLEngineResult;
 import javax.net.ssl.SSLEngineResult.HandshakeStatus;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLSession;
-import java.io.Closeable;
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.channels.SocketChannel;
-import java.util.ArrayList;
-import java.util.List;
+
+import net.spy.memcached.compat.log.Logger;
+import net.spy.memcached.compat.log.LoggerFactory;
 
 public class TLSConnectionManager implements Closeable {
 
@@ -34,8 +37,11 @@ public class TLSConnectionManager implements Closeable {
     private ByteBuffer networkOutBuffer; // Holds the data we are sending across the wire
     private ByteBuffer networkInBuffer; // Holds the data we have received from the wire
 
+    private CountDownLatch handshakeSuccessful;
+
     public TLSConnectionManager(SSLContext sslContext) {
         this.sslContext = sslContext;
+        this.handshakeSuccessful = new CountDownLatch(1);
     }
 
     private void initSslEngine() {
@@ -156,6 +162,7 @@ public class TLSConnectionManager implements Closeable {
         if (LOG.isDebugEnabled()) {
             LOG.debug("%s - Handshake complete.", socketChannel.getRemoteAddress());
         }
+        handshakeSuccessful.countDown();
         return true;
     }
 
@@ -330,5 +337,17 @@ public class TLSConnectionManager implements Closeable {
         public SSLEngineResult getResult() {
             return result;
         }
+    }
+
+    public boolean wasHandshakeSuccessful() {
+        return handshakeSuccessful.getCount() == 0;
+    }
+
+    public boolean awaitHandshake(long msToWait) throws InterruptedException {
+       return handshakeSuccessful.await(msToWait, TimeUnit.MILLISECONDS);
+    }
+
+    public void resetHandshakeStatus() {
+        handshakeSuccessful = new CountDownLatch(1);
     }
 }


### PR DESCRIPTION
While testing, we noticed that the `isAuthed()` method didn't seem to work as expected for TLS connections. This meant that operations would get queued while handshaking and cause the connection to get reset, prompting another handshake. This PR adds a latch that tracks the state of the handshake and prevents operations from being queued while the connection is resetting. 