### PR TITLE
Adds TLS Support to the main branch

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -42,8 +42,10 @@ import net.spy.memcached.ops.VBucketAware;
 import net.spy.memcached.protocol.binary.BinaryOperationFactory;
 import net.spy.memcached.protocol.binary.MultiGetOperationImpl;
 import net.spy.memcached.protocol.binary.TapAckOperationImpl;
+import net.spy.memcached.tls.TLSConnectionManager.UnwrapResult;
 import net.spy.memcached.util.StringUtils;
 
+import javax.net.ssl.SSLEngineResult;
 import java.io.IOException;
 import java.net.ConnectException;
 import java.net.InetSocketAddress;
@@ -842,7 +844,11 @@ public class MemcachedConnection extends SpyThread {
       currentOp = handleReadsWhenChannelEndOfStream(currentOp, node, rbuf);
     }
 
-    while (read > 0) {
+    while (
+            read > 0
+            || (sslEnabled && rbuf.position() > 0)  // If the encrypted data exceeds the size of the read buffer, we'll
+                                                    // need to continue to read until we've decrypted the entire response
+    ) {
       getLogger().debug("Read %d bytes", read);
       rbuf.flip();
       while (rbuf.remaining() > 0) {
@@ -855,13 +861,30 @@ public class MemcachedConnection extends SpyThread {
         metrics.forNode(node).updateHistogram(OVERALL_AVG_TIME_ON_WIRE_METRIC,
             (int)(timeOnWire / 1000));
         metrics.forNode(node).markMeter(OVERALL_RESPONSE_METRIC);
-        synchronized(currentOp) {
-          readBufferAndLogMetrics(currentOp, rbuf, node);
+        if (sslEnabled) {
+          UnwrapResult unwrapResult = node.unwrapReadBuffer(rbuf);
+          if (unwrapResult.getResult().getStatus() == SSLEngineResult.Status.BUFFER_UNDERFLOW) {
+            // We need to continue reading data from the wire
+            break;
+          }
+          // We've finished decrypting the entire response at this point
+          synchronized (currentOp) {
+            readBufferAndLogMetrics(currentOp, unwrapResult.getDataBuffer(), node);
+          }
+          currentOp = node.getCurrentReadOp();
+          break; // Since we're compacting rbuf, we need to escape this while
+        } else {
+          synchronized (currentOp) {
+            readBufferAndLogMetrics(currentOp, rbuf, node);
+          }
+          currentOp = node.getCurrentReadOp();
         }
-
-        currentOp = node.getCurrentReadOp();
       }
-      rbuf.clear();
+      if (sslEnabled) {
+        rbuf.compact(); // There's still more data to be read, so we compact the buffer and continue reading
+      } else {
+        rbuf.clear();
+      }
       read = channel.read(rbuf);
       node.completedRead();
     }

--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -753,7 +753,7 @@ public class MemcachedConnection extends SpyThread {
       if (!handshakeResult) {
         throw new IOException("TLS Handshake Failed on " + node.getSocketAddress());
       }
-      getLogger().info("{} - Handshake Completed", node.getSocketAddress());
+      getLogger().info("%s - Handshake Completed", node.getSocketAddress());
     }
 
     if (verifyAliveOnConnect) {

--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -247,6 +247,8 @@ public class MemcachedConnection extends SpyThread {
    */
   private final int wakeupDelay;
 
+  private final boolean sslEnabled;
+
   /**
    * Construct a {@link MemcachedConnection}.
    *
@@ -276,6 +278,7 @@ public class MemcachedConnection extends SpyThread {
     listenerExecutorService = f.getListenerExecutorService();
     this.bufSize = bufSize;
     this.connectionFactory = f;
+    this.sslEnabled = f.getSslEnabled();
 
     String verifyAlive = System.getProperty("net.spy.verifyAliveOnConnect");
     if(verifyAlive != null && verifyAlive.equals("true")) {
@@ -742,6 +745,14 @@ public class MemcachedConnection extends SpyThread {
    */
   private void finishConnect(final SelectionKey sk, final MemcachedNode node)
       throws IOException {
+
+    if (sslEnabled) {
+      boolean handshakeResult = node.executeTlsHandshake();
+      if (!handshakeResult) {
+        throw new IOException("TLS Handshake Failed on " + node.getSocketAddress());
+      }
+    }
+
     if (verifyAliveOnConnect) {
       final CountDownLatch latch = new CountDownLatch(1);
       final OperationFuture<Boolean> rv = new OperationFuture<Boolean>("noop",

--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -352,6 +352,7 @@ public class MemcachedConnection extends SpyThread {
       try {
         if (ch.connect(sa)) {
           getLogger().info("Connected to %s immediately", qa);
+          getLogger().info("Notifying node connected after creation");
           connected(qa);
         } else {
           getLogger().info("Added %s to connect queue", qa);
@@ -797,6 +798,7 @@ public class MemcachedConnection extends SpyThread {
       }
     }
 
+    getLogger().info("Notifying node connected from finishConnect()");
     connected(node);
     addedQueue.offer(node);
     if (node.getWbuf().hasRemaining()) {
@@ -1138,6 +1140,7 @@ public class MemcachedConnection extends SpyThread {
           ch.socket().setTcpNoDelay(!connectionFactory.useNagleAlgorithm());
           int ops = 0;
           if (ch.connect(node.getSocketAddress())) {
+            getLogger().info("Notifying node connected after reconnect.");
             connected(node);
             addedQueue.offer(node);
             getLogger().info("Immediately reconnected to %s", node);

--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -352,7 +352,6 @@ public class MemcachedConnection extends SpyThread {
       try {
         if (ch.connect(sa)) {
           getLogger().info("Connected to %s immediately", qa);
-          getLogger().info("Notifying node connected after creation");
           connected(qa);
         } else {
           getLogger().info("Added %s to connect queue", qa);
@@ -798,7 +797,6 @@ public class MemcachedConnection extends SpyThread {
       }
     }
 
-    getLogger().info("Notifying node connected from finishConnect()");
     connected(node);
     addedQueue.offer(node);
     if (node.getWbuf().hasRemaining()) {
@@ -1140,7 +1138,6 @@ public class MemcachedConnection extends SpyThread {
           ch.socket().setTcpNoDelay(!connectionFactory.useNagleAlgorithm());
           int ops = 0;
           if (ch.connect(node.getSocketAddress())) {
-            getLogger().info("Notifying node connected after reconnect.");
             connected(node);
             addedQueue.offer(node);
             getLogger().info("Immediately reconnected to %s", node);

--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -753,6 +753,7 @@ public class MemcachedConnection extends SpyThread {
       if (!handshakeResult) {
         throw new IOException("TLS Handshake Failed on " + node.getSocketAddress());
       }
+      getLogger().info("{} - Handshake Completed", node.getSocketAddress());
     }
 
     if (verifyAliveOnConnect) {

--- a/src/main/java/net/spy/memcached/MemcachedNode.java
+++ b/src/main/java/net/spy/memcached/MemcachedNode.java
@@ -31,6 +31,7 @@ import java.nio.channels.SocketChannel;
 import java.util.Collection;
 
 import net.spy.memcached.ops.Operation;
+import net.spy.memcached.tls.TLSConnectionManager.UnwrapResult;
 
 /**
  * Interface defining a connection to a memcached server.
@@ -260,5 +261,13 @@ public interface MemcachedNode {
 	 * @return true if the handshake was a success, false otherwise
 	 */
 	public boolean executeTlsHandshake();
+
+	/**
+	 * Takes a buffer read from the server and unwraps it with the current SSL Context
+	 * @param networkInBuffer The byte buffer of bytes being read
+	 * @return A result with the decrypted bytes and the resulting SSLEngineResult
+	 * @throws IOException if the buffer is null, the buffer is readonly, SSL hasn't been configured, or the connection has closed
+	 */
+	UnwrapResult unwrapReadBuffer(ByteBuffer networkInBuffer) throws IOException;
 
 }

--- a/src/main/java/net/spy/memcached/MemcachedNode.java
+++ b/src/main/java/net/spy/memcached/MemcachedNode.java
@@ -254,4 +254,11 @@ public interface MemcachedNode {
 	 * waiting to be picked up by the event loop.
 	 */
 	int pendingOperationQueueSize();
+
+	/**
+	 * Performs a TLS Handshake with the SSLContext provided by the connection factory
+	 * @return true if the handshake was a success, false otherwise
+	 */
+	public boolean executeTlsHandshake();
+
 }

--- a/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
+++ b/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
@@ -187,6 +187,11 @@ public class MemcachedNodeROImpl implements MemcachedNode {
     return root.pendingOperationQueueSize();
   }
 
+  @Override
+  public boolean executeTlsHandshake() {
+    return root.executeTlsHandshake();
+  }
+
   public boolean isAuthenticated() {
     throw new UnsupportedOperationException();
   }

--- a/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
+++ b/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
@@ -31,6 +31,7 @@ import java.nio.channels.SocketChannel;
 import java.util.Collection;
 
 import net.spy.memcached.ops.Operation;
+import net.spy.memcached.tls.TLSConnectionManager;
 
 public class MemcachedNodeROImpl implements MemcachedNode {
 
@@ -190,6 +191,11 @@ public class MemcachedNodeROImpl implements MemcachedNode {
   @Override
   public boolean executeTlsHandshake() {
     return root.executeTlsHandshake();
+  }
+
+  @Override
+  public TLSConnectionManager.UnwrapResult unwrapReadBuffer(ByteBuffer networkInBuffer) throws IOException {
+    return root.unwrapReadBuffer(networkInBuffer);
   }
 
   public boolean isAuthenticated() {

--- a/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
@@ -37,7 +37,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
-
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLException;
 import net.jodah.failsafe.CircuitBreaker;
 import net.jodah.failsafe.function.CheckedRunnable;
 import net.spy.memcached.ConnectionFactory;
@@ -50,9 +51,6 @@ import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.protocol.binary.TapAckOperationImpl;
 import net.spy.memcached.tls.TLSConnectionManager;
 import net.spy.memcached.tls.TLSConnectionManager.UnwrapResult;
-
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLException;
 
 /**
  * Represents a node with the memcached cluster, along with buffering and
@@ -281,7 +279,7 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject implements
                 int wrapResult = tlsConnectionManager.wrapBufferForSend(obuf, getWbuf());
                 if (wrapResult == TLSConnectionManager.WRAP_STATUS_BUFFER_OVERFLOW) {
                   tlsError = true;
-                  getLogger().error("Buffer overflow wrapping operation for TLS. Operation: %s", o);
+                  getLogger().warn("Buffer overflow wrapping operation for TLS. Operation: %s", o);
                 } else {
                   toWrite += wrapResult;
                 }

--- a/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
@@ -279,7 +279,6 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject implements
                 int wrapResult = tlsConnectionManager.wrapBufferForSend(obuf, getWbuf());
                 if (wrapResult == TLSConnectionManager.WRAP_STATUS_BUFFER_OVERFLOW) {
                   tlsError = true;
-                  getLogger().warn("Buffer overflow wrapping operation for TLS. Operation: %s", o);
                 } else {
                   toWrite += wrapResult;
                 }

--- a/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
@@ -37,8 +37,10 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
+
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLException;
+
 import net.jodah.failsafe.CircuitBreaker;
 import net.jodah.failsafe.function.CheckedRunnable;
 import net.spy.memcached.ConnectionFactory;
@@ -426,7 +428,7 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject implements
    */
   public final void addOp(Operation op) {
     try {
-      if (!authLatch.await(authWaitTime, TimeUnit.MILLISECONDS)) {
+      if (!authLatch.await(authWaitTime, TimeUnit.MILLISECONDS) && awaitSslHandshakeMaybe()) {
         FailureMode mode = connectionFactory.getFailureMode();
         if (mode == FailureMode.Redistribute || mode == FailureMode.Retry) {
           getLogger().debug("Redistributing Operation " + op + " because auth "
@@ -544,6 +546,9 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject implements
    * @see net.spy.memcached.MemcachedNode#isAuthenticated()
    */
   public boolean isAuthenticated() {
+    if (sslEnabled) {
+      return tlsConnectionManager.wasHandshakeSuccessful();
+    }
     return (0 == authLatch.getCount());
   }
 
@@ -740,6 +745,7 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject implements
     }
   }
 
+  // Only called for SASL auth
   public final void authComplete() {
     if (reconnectBlocked != null && reconnectBlocked.size() > 0) {
       inputQueue.addAll(reconnectBlocked);
@@ -748,6 +754,9 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject implements
   }
 
   public final void setupForAuth() {
+    if (sslEnabled) {
+      tlsConnectionManager.resetHandshakeStatus();
+    }
     if (shouldAuth) {
       authLatch = new CountDownLatch(1);
       if (inputQueue.size() > 0) {
@@ -769,6 +778,13 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject implements
         getLogger().error("SSL Handshake Failed", e);
         return false;
       }
+  }
+
+  private boolean awaitSslHandshakeMaybe() throws InterruptedException {
+    if (sslEnabled) {
+      return tlsConnectionManager.awaitHandshake(authWaitTime);
+    }
+    return true;
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
@@ -746,7 +746,8 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject implements
     }
   }
 
-  private boolean executeTlsHandshake() {
+  @Override
+  public boolean executeTlsHandshake() {
       try {
         return tlsConnectionManager.doHandshake(channel);
       } catch (IOException e) {

--- a/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
@@ -282,13 +282,13 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject implements
                 if (wrapResult == TLSConnectionManager.WRAP_STATUS_BUFFER_OVERFLOW) {
                   tlsError = true;
                   // Todo: Should we resize the network buffer here and retry the operation? Should the operation error out?
-                  getLogger().error("Buffer overflow wrapping operation for TLS. Operation: {}", o);
+                  getLogger().error("Buffer overflow wrapping operation for TLS. Operation: %s", o);
                 } else {
                   toWrite += wrapResult;
                 }
               } catch (SSLException e) {
                   tlsError = true;
-                  getLogger().error("Failed to wrap operation for TLS. Operation: {}", o, e);
+                  getLogger().error("Failed to wrap operation for TLS. Operation: %s", o, e);
               }
           }
           int bytesToCopy = Math.min(getWbuf().remaining(), obuf.remaining());

--- a/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
@@ -31,6 +31,7 @@ import java.nio.channels.SelectionKey;
 import java.nio.channels.SocketChannel;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -47,6 +48,9 @@ import net.spy.memcached.compat.SpyObject;
 import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.protocol.binary.TapAckOperationImpl;
+import net.spy.memcached.tls.TLSConnectionManager;
+
+import javax.net.ssl.SSLContext;
 
 /**
  * Represents a node with the memcached cluster, along with buffering and
@@ -84,6 +88,10 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject implements
   private int continuousTimeout = 0;
   private long continuousTimeoutStart = 0;
 
+  private final boolean sslEnabled;
+  private final Optional<SSLContext> sslContext;
+  private final TLSConnectionManager tlsConnectionManager;
+
   public TCPMemcachedNodeImpl(SocketAddress sa, SocketChannel c, int bufSize,
                               BlockingQueue<Operation> rq, BlockingQueue<Operation> wq,
                               BlockingQueue<Operation> iq, long opQueueMaxBlockTime,
@@ -98,6 +106,13 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject implements
     socketAddress = sa;
     connectionFactory = fact;
     this.authWaitTime = authWaitTime;
+    this.sslEnabled = fact.getSslEnabled();
+    this.sslContext = fact.getSslContext();
+    if (sslEnabled && sslContext.isEmpty()) {
+      throw new IllegalStateException("SSL Context was empty, but SSL was enabled");
+    }
+    this.tlsConnectionManager = sslEnabled ? new TLSConnectionManager(sslContext.get()) : null;
+
     setChannel(c);
     // Since these buffers are allocated rarely (only on client creation
     // or reconfigure), and are passed to Channel.read() and Channel.write(),
@@ -729,6 +744,15 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject implements
     } else {
       authLatch = new CountDownLatch(0);
     }
+  }
+
+  private boolean executeTlsHandshake() {
+      try {
+        return tlsConnectionManager.doHandshake(channel);
+      } catch (IOException e) {
+        getLogger().error("SSL Handshake Failed", e);
+        return false;
+      }
   }
 
   /**

--- a/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
@@ -49,8 +49,10 @@ import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.protocol.binary.TapAckOperationImpl;
 import net.spy.memcached.tls.TLSConnectionManager;
+import net.spy.memcached.tls.TLSConnectionManager.UnwrapResult;
 
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLException;
 
 /**
  * Represents a node with the memcached cluster, along with buffering and
@@ -118,8 +120,8 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject implements
     // or reconfigure), and are passed to Channel.read() and Channel.write(),
     // use direct buffers to avoid
     //   http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6214569
-    rbuf = ByteBuffer.allocateDirect(bufSize);
-    wbuf = ByteBuffer.allocateDirect(bufSize);
+    rbuf = sslEnabled ? tlsConnectionManager.allocateNetworkBuffer(bufSize) : ByteBuffer.allocateDirect(bufSize);
+    wbuf = sslEnabled ? tlsConnectionManager.allocateNetworkBuffer(bufSize) : ByteBuffer.allocateDirect(bufSize);
     getWbuf().clear();
     readQ = rq;
     writeQ = wq;
@@ -267,12 +269,28 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject implements
       getWbuf().clear();
       Operation o=getNextWritableOp();
 
-      while(o != null && toWrite < getWbuf().capacity()) {
+      boolean tlsError = false;
+      while(o != null && toWrite < getWbuf().capacity() && !tlsError) {
         synchronized(o) {
           assert o.getState() == OperationState.WRITING;
 
           ByteBuffer obuf = o.getBuffer();
           assert obuf != null : "Didn't get a write buffer from " + o;
+          if (sslEnabled) {
+              try {
+                int wrapResult = tlsConnectionManager.wrapBufferForSend(obuf, getWbuf());
+                if (wrapResult == TLSConnectionManager.WRAP_STATUS_BUFFER_OVERFLOW) {
+                  tlsError = true;
+                  // Todo: Should we resize the network buffer here and retry the operation? Should the operation error out?
+                  getLogger().error("Buffer overflow wrapping operation for TLS. Operation: {}", o);
+                } else {
+                  toWrite += wrapResult;
+                }
+              } catch (SSLException e) {
+                  tlsError = true;
+                  getLogger().error("Failed to wrap operation for TLS. Operation: {}", o, e);
+              }
+          }
           int bytesToCopy = Math.min(getWbuf().remaining(), obuf.remaining());
           byte[] b = new byte[bytesToCopy];
           obuf.get(b);
@@ -754,6 +772,11 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject implements
         getLogger().error("SSL Handshake Failed", e);
         return false;
       }
+  }
+
+  @Override
+  public UnwrapResult unwrapReadBuffer(ByteBuffer networkInBuffer) throws IOException {
+    return tlsConnectionManager.unwrapReceivedBuffer(networkInBuffer);
   }
 
   /**

--- a/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
@@ -281,7 +281,6 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject implements
                 int wrapResult = tlsConnectionManager.wrapBufferForSend(obuf, getWbuf());
                 if (wrapResult == TLSConnectionManager.WRAP_STATUS_BUFFER_OVERFLOW) {
                   tlsError = true;
-                  // Todo: Should we resize the network buffer here and retry the operation? Should the operation error out?
                   getLogger().error("Buffer overflow wrapping operation for TLS. Operation: %s", o);
                 } else {
                   toWrite += wrapResult;
@@ -290,12 +289,14 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject implements
                   tlsError = true;
                   getLogger().error("Failed to wrap operation for TLS. Operation: %s", o, e);
               }
+          } else {
+            int bytesToCopy = Math.min(getWbuf().remaining(), obuf.remaining());
+            byte[] b = new byte[bytesToCopy];
+            obuf.get(b);
+            getWbuf().put(b);
+            getLogger().debug("After copying stuff from %s: %s", o, getWbuf());
+            toWrite += bytesToCopy;
           }
-          int bytesToCopy = Math.min(getWbuf().remaining(), obuf.remaining());
-          byte[] b = new byte[bytesToCopy];
-          obuf.get(b);
-          getWbuf().put(b);
-          getLogger().debug("After copying stuff from %s: %s", o, getWbuf());
           if (!o.getBuffer().hasRemaining()) {
             o.writeComplete();
             transitionWriteItem();
@@ -307,7 +308,6 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject implements
 
             o=getNextWritableOp();
           }
-          toWrite += bytesToCopy;
         }
       }
       getWbuf().flip();

--- a/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
+++ b/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
@@ -204,4 +204,13 @@ public class TLSConnectionManager implements Closeable {
             }
         }
     }
+
+    public static ArrayList<Byte> extractByteBuffer(ByteBuffer buffer) {
+        ByteBuffer duplicate = buffer.duplicate();
+        ArrayList<Byte> bytes = new ArrayList<>();
+        for(int i = 0; i < duplicate.remaining(); i++) {
+            bytes.add(duplicate.get());
+        }
+        return bytes;
+    }
 }

--- a/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
+++ b/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
@@ -55,7 +55,7 @@ public class TLSConnectionManager implements Closeable {
     }
 
     public boolean doHandshake(SocketChannel socketChannel) throws IOException {
-        LOG.info("%s - Beginning handshake.", socketChannel.getRemoteAddress());
+        LOG.debug("%s - Beginning handshake.", socketChannel.getRemoteAddress());
         try {
             sslEngine.beginHandshake();
             currentSession = sslEngine.getSession();
@@ -65,7 +65,7 @@ public class TLSConnectionManager implements Closeable {
             while (!Thread.currentThread().isInterrupted()
                     && handshakeStatus != HandshakeStatus.FINISHED
                     && handshakeStatus != HandshakeStatus.NOT_HANDSHAKING) {
-                LOG.info("%s - Handshake status: %s", socketChannel.getRemoteAddress(), handshakeStatus.name());
+                LOG.debug("%s - Handshake status: %s", socketChannel.getRemoteAddress(), handshakeStatus.name());
                 switch (handshakeStatus) {
                     case NEED_TASK:
                         // we need to finish these tasks for the handshake to continue

--- a/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
+++ b/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
@@ -65,7 +65,7 @@ public class TLSConnectionManager implements Closeable {
             while (!Thread.currentThread().isInterrupted()
                     && handshakeStatus != HandshakeStatus.FINISHED
                     && handshakeStatus != HandshakeStatus.NOT_HANDSHAKING) {
-                LOG.debug("{} - Handshake status: {}", socketChannel.getRemoteAddress(), handshakeStatus.name());
+                LOG.info("{} - Handshake status: {}", socketChannel.getRemoteAddress(), handshakeStatus.name());
                 switch (handshakeStatus) {
                     case NEED_TASK:
                         // we need to finish these tasks for the handshake to continue

--- a/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
+++ b/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
@@ -25,6 +25,10 @@ public class TLSConnectionManager implements Closeable {
     private final SSLContext sslContext;
     private SSLEngine sslEngine;
 
+    public static final int WRAP_STATUS_BUFFER_UNDERFLOW = -1;
+    public static final int WRAP_STATUS_BUFFER_OVERFLOW = -2;
+
+
     private SSLSession currentSession;
 
     private ByteBuffer appOutBuffer; // Holds the data we are preparing to send out
@@ -50,10 +54,10 @@ public class TLSConnectionManager implements Closeable {
 
     private void initBuffers(SSLSession session) {
         // allocateDirect() to keep all bytes contiguous in memory
-        appOutBuffer = ByteBuffer.allocateDirect(session.getApplicationBufferSize());
-        appInBuffer = ByteBuffer.allocateDirect(session.getApplicationBufferSize());
-        networkOutBuffer = ByteBuffer.allocateDirect(session.getPacketBufferSize());
-        networkInBuffer = ByteBuffer.allocateDirect(session.getPacketBufferSize());
+        appOutBuffer = allocateAppBuffer();
+        appInBuffer = allocateAppBuffer();
+        networkOutBuffer = allocateNetworkBuffer();
+        networkInBuffer = allocateNetworkBuffer();
     }
 
     public boolean doHandshake(SocketChannel socketChannel) throws IOException {
@@ -150,6 +154,60 @@ public class TLSConnectionManager implements Closeable {
         return true;
     }
 
+    /**
+     * Uses the keys stored in the SSLEngine to encrypt byts to send to the server
+     * @param appOutBuffer The buffer containing the unencrypted data to send. Should be at least sslEngine.getApplicationBufferSize() in length.
+     * @param networkOutBuffer The buffer to write to, should be at least sslEngine.getPacketBuffer() in length
+     * @return If the wrap succeeds, the number of bytes produced by the wrap.
+     *         If a Buffer Overflow happened, TLSConnectionManager.WRAP_STATUS_BUFFER_OVERFLOW
+     *         If a Buffer Underflow happened, TLSConnectionManager.WRAP_STATUS_BUFFER_UNDERFLOW
+     * @throws SSLException from the call to SSLEngine::wrap if any occurred
+     */
+    public int wrapBufferForSend(ByteBuffer appOutBuffer, ByteBuffer networkOutBuffer) throws SSLException {
+        SSLEngineResult wrap = sslEngine.wrap(appOutBuffer, networkOutBuffer);
+        switch (wrap.getStatus()) {
+            case BUFFER_UNDERFLOW:
+                return WRAP_STATUS_BUFFER_UNDERFLOW;
+            case BUFFER_OVERFLOW:
+                return WRAP_STATUS_BUFFER_OVERFLOW;
+            case OK:
+                return wrap.bytesProduced();
+            case CLOSED:
+                throw new RuntimeException(sslEngine.getPeerHost() + " - TLS Connection is closed");
+            default:
+                // This might get hit if the Status enum ever gets expanded, but for now, we should not hit this. Case
+                // required to make the Java compiler happy.
+                throw new IllegalStateException("Invalid SSL status: " + wrap.getStatus());
+        }
+    }
+
+    public UnwrapResult unwrapReceivedBuffer (ByteBuffer networkInBuffer) throws IOException {
+        appInBuffer.clear();
+        while(!Thread.currentThread().isInterrupted()) {
+        SSLEngineResult unwrapResult = sslEngine.unwrap(networkInBuffer, appInBuffer);
+            switch (unwrapResult.getStatus()) {
+                case BUFFER_OVERFLOW:
+                    // Application buffer is too small, set it to the correct size
+                    enlargeBuffer(appInBuffer, sslEngine.getSession().getApplicationBufferSize());
+                    break;
+                case BUFFER_UNDERFLOW:
+                    // We aren't done reading the response yet
+                    return new UnwrapResult(null, unwrapResult);
+                case OK:
+                    appInBuffer.flip();
+                    return new UnwrapResult(appInBuffer, unwrapResult);
+                case CLOSED:
+                    this.close();
+                    throw new IOException(sslEngine.getPeerHost() + " - TLS Connection is closed");
+                default:
+                    // This might get hit if the Status enum ever gets expanded, but for now, we should not hit this. Case
+                    // required to make the Java compiler happy.
+                    throw new IllegalStateException("Invalid SSL status: " + unwrapResult.getStatus());
+            }
+        }
+        throw new RuntimeException(sslEngine.getPeerHost() + " - Interrupted while unwrapping read buffer");
+    }
+
     @Override
     public void close() throws IOException {
         closeSslEngine();
@@ -208,12 +266,30 @@ public class TLSConnectionManager implements Closeable {
         }
     }
 
+    public ByteBuffer allocateAppBuffer() {
+        return allocateAppBuffer(0);
+    }
+
+    public ByteBuffer allocateAppBuffer(int suggestedSize) {
+        int requiredSize = Math.max(sslEngine.getSession().getApplicationBufferSize(), suggestedSize);
+        return ByteBuffer.allocateDirect(requiredSize);
+    }
+
+    public ByteBuffer allocateNetworkBuffer() {
+        return ByteBuffer.allocateDirect(0);
+    }
+
+    public ByteBuffer allocateNetworkBuffer(int suggestedSize) {
+        int requiredSize = Math.max(sslEngine.getSession().getPacketBufferSize(), suggestedSize);
+        return ByteBuffer.allocateDirect(requiredSize);
+    }
+
     private static ByteBuffer enlargeBuffer(ByteBuffer buffer, int suggestedCapacity) {
         if (suggestedCapacity > buffer.capacity()) {
-            return ByteBuffer.allocate(suggestedCapacity);
+            return ByteBuffer.allocateDirect(suggestedCapacity);
         } else {
             // If the suggested capacity is still too small, double the size
-            return ByteBuffer.allocate(buffer.capacity() * 2);
+            return ByteBuffer.allocateDirect(buffer.capacity() * 2);
         }
     }
 
@@ -226,6 +302,24 @@ public class TLSConnectionManager implements Closeable {
             } catch (IOException e) {
                 throw new SSLException("Failed to write wrapped buffer.", e);
             }
+        }
+    }
+    
+    public static class UnwrapResult {
+        private final ByteBuffer dataBuffer;
+        private final SSLEngineResult result;
+
+        private UnwrapResult(ByteBuffer dataBuffer, SSLEngineResult result) {
+            this.dataBuffer = dataBuffer;
+            this.result = result;
+        }
+
+        public ByteBuffer getDataBuffer() {
+            return dataBuffer;
+        }
+
+        public SSLEngineResult getResult() {
+            return result;
         }
     }
 }

--- a/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
+++ b/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
@@ -65,6 +65,7 @@ public class TLSConnectionManager implements Closeable {
             while (!Thread.currentThread().isInterrupted()
                     && handshakeStatus != HandshakeStatus.FINISHED
                     && handshakeStatus != HandshakeStatus.NOT_HANDSHAKING) {
+                LOG.debug("{} - Handshake status: {}", socketChannel.getRemoteAddress(), handshakeStatus.name());
                 switch (handshakeStatus) {
                     case NEED_TASK:
                         // we need to finish these tasks for the handshake to continue

--- a/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
+++ b/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
@@ -24,7 +24,8 @@ public class TLSConnectionManager implements Closeable {
 
     private static final Logger LOG = LoggerFactory.getLogger(TLSConnectionManager.class);
 
-    private final SSLEngine sslEngine;
+    private final SSLContext sslContext;
+    private SSLEngine sslEngine;
 
     private SSLSession currentSession;
 
@@ -36,13 +37,18 @@ public class TLSConnectionManager implements Closeable {
     ExecutorService executor = Executors.newSingleThreadExecutor();
 
     public TLSConnectionManager(SSLContext sslContext) {
-        this.sslEngine = sslContext.createSSLEngine();
-
-        configureSslEngine();
+        this.sslContext = sslContext;
     }
 
-    private void configureSslEngine() {
+    private void initSSLEngine() {
         // We are the client, not the server
+        if (sslEngine != null) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Resetting SSL Engine");
+            }
+            closeSslEngine();
+        }
+        sslEngine = sslContext.createSSLEngine();
         sslEngine.setUseClientMode(true);
     }
 
@@ -55,17 +61,24 @@ public class TLSConnectionManager implements Closeable {
     }
 
     public boolean doHandshake(SocketChannel socketChannel) throws IOException {
-        LOG.debug("%s - Beginning handshake.", socketChannel.getRemoteAddress());
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("%s - Beginning handshake.", socketChannel.getRemoteAddress());
+        }
+
         try {
+            initSSLEngine();
             sslEngine.beginHandshake();
             currentSession = sslEngine.getSession();
             initBuffers(currentSession);
 
             HandshakeStatus handshakeStatus = sslEngine.getHandshakeStatus();
+            if (LOG.isDebugEnabled()) {
+                LOG.info("%s - Handshake status: %s", socketChannel.getRemoteAddress(), handshakeStatus.name());
+            }
             while (!Thread.currentThread().isInterrupted()
                     && handshakeStatus != HandshakeStatus.FINISHED
                     && handshakeStatus != HandshakeStatus.NOT_HANDSHAKING) {
-                LOG.debug("%s - Handshake status: %s", socketChannel.getRemoteAddress(), handshakeStatus.name());
+
                 switch (handshakeStatus) {
                     case NEED_TASK:
                         // we need to finish these tasks for the handshake to continue
@@ -99,7 +112,14 @@ public class TLSConnectionManager implements Closeable {
                                 return false;
                             }
                             // We're done with the handshake, signal that we aren't going to be sending or receiving any more data
-                            sslEngine.closeInbound();
+                            try {
+                                sslEngine.closeInbound();
+                            } catch (SSLException e) {
+                                if (LOG.isDebugEnabled()) {
+                                    // This doesn't seem to be critical, but it could be nice to know about
+                                    LOG.warn("{} - tried to close inbound traffic but has not received a TLS close notification yet due to end of stream.", socketChannel.getRemoteAddress(), e);
+                                }
+                            }
                             sslEngine.closeOutbound();
                             break;
                         }
@@ -118,6 +138,9 @@ public class TLSConnectionManager implements Closeable {
                 }
 
                 handshakeStatus = sslEngine.getHandshakeStatus();
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("%s - Handshake status: %s", socketChannel.getRemoteAddress(), handshakeStatus.name());
+                }
             }
 
             // If we were interrupted, get out
@@ -130,14 +153,29 @@ public class TLSConnectionManager implements Closeable {
         } catch (SSLException | InterruptedException e) {
             throw new RuntimeException("Caught exception during SSL Handshake", e);
         }
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("%s - Handshake complete.", socketChannel.getRemoteAddress());
+        }
         return true;
     }
 
     @Override
     public void close() throws IOException {
+        closeSslEngine();
+    }
+
+    private void closeSslEngine() {
         sslEngine.setEnableSessionCreation(false);
         sslEngine.closeOutbound();
-        sslEngine.closeInbound();
+        try {
+            sslEngine.closeInbound();
+        } catch (SSLException e) {
+            if (LOG.isDebugEnabled()) {
+                // This doesn't seem to be critical, but it could be nice to know about
+                LOG.warn("Tried to close inbound traffic but has not received a TLS close notification yet due to end of stream.", e);
+            }
+        }
+        sslEngine = null;
     }
 
     private void handleHandshakeWrapResult(SocketChannel socketChannel, SSLEngineResult result) throws SSLException {
@@ -189,7 +227,7 @@ public class TLSConnectionManager implements Closeable {
     }
 
     private void sendNetworkBuffer(SocketChannel socketChannel) throws SSLException {
-        networkOutBuffer.flip(); // Change from read to write
+        networkOutBuffer.flip(); // Change from reading to writing
         // Send data over the wire
         while(networkOutBuffer.hasRemaining()) {
             try {
@@ -198,14 +236,5 @@ public class TLSConnectionManager implements Closeable {
                 throw new SSLException("Failed to write wrapped buffer.", e);
             }
         }
-    }
-
-    public static ArrayList<Byte> extractByteBuffer(ByteBuffer buffer) {
-        ByteBuffer duplicate = buffer.duplicate();
-        ArrayList<Byte> bytes = new ArrayList<>();
-        for(int i = 0; i < duplicate.remaining(); i++) {
-            bytes.add(duplicate.get());
-        }
-        return bytes;
     }
 }

--- a/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
+++ b/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
@@ -99,8 +99,8 @@ public class TLSConnectionManager implements Closeable {
                                 return false;
                             }
                             // We're done with the handshake, signal that we aren't going to be sending or receiving any more data
-                            sslEngine.closeInbound();
                             sslEngine.closeOutbound();
+                            sslEngine.closeInbound();
                             break;
                         }
                         networkInBuffer.flip();

--- a/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
+++ b/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
@@ -1,0 +1,198 @@
+package net.spy.memcached.tls;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLEngineResult;
+import javax.net.ssl.SSLEngineResult.HandshakeStatus;
+import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLSession;
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.SocketChannel;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+public class TLSConnectionManager implements Closeable {
+
+    private final SSLContext sslContext;
+    private final SSLEngine sslEngine;
+
+    private SSLSession currentSession;
+
+    private ByteBuffer appOutBuffer; // Holds the data we are preparing to send out
+    private ByteBuffer appInBuffer; // Holds the data we have received and unwrapped
+    private ByteBuffer networkOutBuffer; // Holds the data we are sending across the wire
+    private ByteBuffer networkInBuffer; // Holds the data we have received from the wire
+
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+
+    public TLSConnectionManager(SSLContext sslContext) {
+        this.sslContext = sslContext;
+        this.sslEngine = sslContext.createSSLEngine();
+
+        configureSslEngine();
+    }
+
+    private void configureSslEngine() {
+        // We are the client, not the server
+        sslEngine.setUseClientMode(true);
+    }
+
+    private void initBuffers(SSLSession session) {
+        // allocateDirect() to keep all bytes contiguous in memory
+        appOutBuffer = ByteBuffer.allocateDirect(session.getApplicationBufferSize());
+        appInBuffer = ByteBuffer.allocateDirect(session.getApplicationBufferSize());
+        networkOutBuffer = ByteBuffer.allocateDirect(session.getPacketBufferSize());
+        networkInBuffer = ByteBuffer.allocateDirect(session.getPacketBufferSize());
+    }
+
+    public boolean doHandshake(SocketChannel socketChannel) throws IOException {
+
+        try {
+            sslEngine.beginHandshake();
+            currentSession = sslEngine.getHandshakeSession();
+            initBuffers(currentSession);
+
+            HandshakeStatus handshakeStatus = sslEngine.getHandshakeStatus();
+            while (!Thread.currentThread().isInterrupted()
+                    && handshakeStatus != HandshakeStatus.FINISHED
+                    && handshakeStatus != HandshakeStatus.NOT_HANDSHAKING) {
+                switch (handshakeStatus) {
+                    case NEED_TASK:
+                        // we need to finish these tasks for the handshake to continue
+                        List<Future<?>> tasks = new ArrayList<>();
+                        Runnable currentTask = sslEngine.getDelegatedTask();
+                        while(currentTask != null) {
+                            tasks.add(executor.submit(currentTask));
+                            currentTask = sslEngine.getDelegatedTask();
+                        }
+                        for (Future<?> task : tasks) {
+                            try {
+                                task.get();
+                            } catch (ExecutionException e) {
+                                // TODO make this more clear
+                                throw new RuntimeException(e);
+                            }
+                        }
+                        break;
+                    case NEED_WRAP:
+                        // We're about to send something to the server, but it needs to be wrapped first
+                        networkOutBuffer.clear();
+                        SSLEngineResult wrapResult = sslEngine.wrap(appOutBuffer, networkOutBuffer);
+                        handleHandshakeWrapResult(socketChannel, wrapResult);
+                        break;
+                    case NEED_UNWRAP:
+                        // We need to receive a message from the server, but it needs to be unwrapped first
+                        if (socketChannel.read(networkInBuffer) < 0) {
+                            // The message was empty
+                            if (sslEngine.isInboundDone() && sslEngine.isOutboundDone()) {
+                                // SSL Engine closed before handshake could complete
+                                return false;
+                            }
+                            // We're done with the handshake, signal that we aren't going to be sending or receiving any more data
+                            sslEngine.closeInbound();
+                            sslEngine.closeOutbound();
+                            break;
+                        }
+                        networkOutBuffer.flip();
+                        SSLEngineResult unwrapResult = sslEngine.unwrap(networkInBuffer, appInBuffer);
+                        networkOutBuffer.compact(); // Leaves any unread bytes while creating more room in the buffer
+                        if (unwrapResult.getStatus() == SSLEngineResult.Status.CLOSED) {
+                            return false; // Server closed session before handshake completed
+                        }
+                        handleHandshakeUnwrapResult(socketChannel, unwrapResult);
+                        break;
+                    case NEED_UNWRAP_AGAIN:
+                        throw new UnsupportedOperationException("DTLS not supported");
+                    default:
+                        throw new IllegalStateException("Invalid SSL status: " + handshakeStatus);
+                }
+
+                handshakeStatus = sslEngine.getHandshakeStatus();
+            }
+
+            // If we were interrupted, get out
+            if (Thread.currentThread().isInterrupted()) {
+                this.close();
+                throw new InterruptedException("Thread interrupted while completing SSL Handshake");
+            }
+
+
+        } catch (SSLException | InterruptedException e) {
+            throw new RuntimeException("Caught exception during SSL Handshake", e);
+        }
+        return true;
+    }
+
+    @Override
+    public void close() throws IOException {
+        sslEngine.setEnableSessionCreation(false);
+        sslEngine.closeOutbound();
+        sslEngine.closeInbound();
+    }
+
+    private void handleHandshakeWrapResult(SocketChannel socketChannel, SSLEngineResult result) throws SSLException {
+        switch (result.getStatus()) {
+            case BUFFER_UNDERFLOW:
+                // We should not get here
+                throw new SSLException("Buffer underflow occurred after wrap");
+            case BUFFER_OVERFLOW:
+                // If networkOutBuffer is too small to contain the response
+                networkOutBuffer = enlargeBuffer(networkOutBuffer, sslEngine.getSession().getPacketBufferSize());
+                // Try again with new larger buffer
+                break;
+            case OK:
+                sendNetworkBuffer(socketChannel);
+                break;
+            case CLOSED:
+                // We need to tell the server we're closing
+                sendNetworkBuffer(socketChannel);
+                // The next status will be NEED_UNWRAP and we'll need to pre-emptively clear the input network data
+                networkInBuffer.clear();
+                break;
+        }
+    }
+
+    private void handleHandshakeUnwrapResult(SocketChannel socketChannel, SSLEngineResult result) throws SSLException {
+        switch (result.getStatus()) {
+            case BUFFER_UNDERFLOW:
+                // If the network buffer is too small
+                networkInBuffer = enlargeBuffer(networkInBuffer, sslEngine.getSession().getPacketBufferSize());
+                break;
+            case BUFFER_OVERFLOW:
+                // if networkInBuffer is larger than appInBuffer
+                appInBuffer = enlargeBuffer(appInBuffer, sslEngine.getSession().getApplicationBufferSize());
+                // try again with larger buffer
+                break;
+            case OK:
+            case CLOSED:
+                break;
+        }
+    }
+
+    private static ByteBuffer enlargeBuffer(ByteBuffer buffer, int suggestedCapacity) {
+        if (suggestedCapacity > buffer.capacity()) {
+            return ByteBuffer.allocate(suggestedCapacity);
+        } else {
+            // If the suggested capacity is still too small, double the size
+            return ByteBuffer.allocate(buffer.capacity() * 2);
+        }
+    }
+
+    private void sendNetworkBuffer(SocketChannel socketChannel) throws SSLException {
+        networkOutBuffer.flip(); // Change from read to write
+        // Send data over the wire
+        while(networkOutBuffer.hasRemaining()) {
+            try {
+                socketChannel.write(networkOutBuffer);
+            } catch (IOException e) {
+                throw new SSLException("Failed to write wrapped buffer.", e);
+            }
+        }
+    }
+}

--- a/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
+++ b/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
@@ -160,7 +160,7 @@ public class TLSConnectionManager implements Closeable {
     }
 
     /**
-     * Uses the keys stored in the SSLEngine to encrypt byts to send to the server
+     * Uses the keys stored in the SSLEngine to encrypt bytes to send to the server
      * @param appOutBuffer The buffer containing the unencrypted data to send. Should be at least sslEngine.getApplicationBufferSize() in length.
      * @param networkOutBuffer The buffer to write to, should be at least sslEngine.getPacketBuffer() in length
      * @return If the wrap succeeds, the number of bytes produced by the wrap.
@@ -189,7 +189,7 @@ public class TLSConnectionManager implements Closeable {
     public UnwrapResult unwrapReceivedBuffer (ByteBuffer networkInBuffer) throws IOException {
         appInBuffer.clear();
         while(!Thread.currentThread().isInterrupted()) {
-        SSLEngineResult unwrapResult = sslEngine.unwrap(networkInBuffer, appInBuffer);
+            SSLEngineResult unwrapResult = sslEngine.unwrap(networkInBuffer, appInBuffer);
             switch (unwrapResult.getStatus()) {
                 case BUFFER_OVERFLOW:
                     // Application buffer is too small, set it to the correct size

--- a/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
+++ b/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
@@ -15,8 +15,6 @@ import java.nio.ByteBuffer;
 import java.nio.channels.SocketChannel;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
 
 public class TLSConnectionManager implements Closeable {
 
@@ -40,20 +38,27 @@ public class TLSConnectionManager implements Closeable {
         this.sslContext = sslContext;
     }
 
-    private void initSSLEngine() {
+    private void initSslEngine() {
+        ensureSslEngineInitialized(true);
+    }
+
+    private void ensureSslEngineInitialized(boolean forceReset) {
         // We are the client, not the server
         if (sslEngine != null) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Resetting SSL Engine");
+            if (forceReset) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Resetting SSL Engine");
+                }
+                closeSslEngine();
+            } else {
+                return;
             }
-            closeSslEngine();
         }
         sslEngine = sslContext.createSSLEngine();
         sslEngine.setUseClientMode(true);
     }
 
     private void initBuffers(SSLSession session) {
-        // allocateDirect() to keep all bytes contiguous in memory
         appOutBuffer = allocateAppBuffer();
         appInBuffer = allocateAppBuffer();
         networkOutBuffer = allocateNetworkBuffer();
@@ -66,7 +71,7 @@ public class TLSConnectionManager implements Closeable {
         }
 
         try {
-            initSSLEngine();
+            initSslEngine();
             sslEngine.beginHandshake();
             currentSession = sslEngine.getSession();
             initBuffers(currentSession);
@@ -271,7 +276,9 @@ public class TLSConnectionManager implements Closeable {
     }
 
     public ByteBuffer allocateAppBuffer(int suggestedSize) {
+        ensureSslEngineInitialized(false);
         int requiredSize = Math.max(sslEngine.getSession().getApplicationBufferSize(), suggestedSize);
+        // allocateDirect() to keep all bytes contiguous in memory
         return ByteBuffer.allocateDirect(requiredSize);
     }
 
@@ -280,7 +287,9 @@ public class TLSConnectionManager implements Closeable {
     }
 
     public ByteBuffer allocateNetworkBuffer(int suggestedSize) {
+        ensureSslEngineInitialized(false);
         int requiredSize = Math.max(sslEngine.getSession().getPacketBufferSize(), suggestedSize);
+        // allocateDirect() to keep all bytes contiguous in memory
         return ByteBuffer.allocateDirect(requiredSize);
     }
 

--- a/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
+++ b/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
@@ -104,6 +104,11 @@ public class TLSConnectionManager implements Closeable {
                             break;
                         }
                         networkOutBuffer.flip();
+                        ByteBuffer bufferContent = networkOutBuffer.duplicate();
+                        ArrayList<Byte> bytes = new ArrayList<>();
+                        for(int i = 0; i < bufferContent.remaining(); i++) {
+                            bufferContent.put(bufferContent.get());
+                        }
                         SSLEngineResult unwrapResult = sslEngine.unwrap(networkInBuffer, appInBuffer);
                         networkOutBuffer.compact(); // Leaves any unread bytes while creating more room in the buffer
                         if (unwrapResult.getStatus() == SSLEngineResult.Status.CLOSED) {

--- a/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
+++ b/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
@@ -97,7 +97,7 @@ public class TLSConnectionManager implements Closeable {
                     case NEED_UNWRAP:
                         // We need to receive a message from the server, but it needs to be unwrapped first
                         if (socketChannel.read(networkInBuffer) < 0) {
-                            // The message was empty
+                            // The message hit the end of the stream
                             if (sslEngine.isInboundDone() && sslEngine.isOutboundDone()) {
                                 // SSL Engine closed before handshake could complete
                                 return false;

--- a/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
+++ b/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
@@ -58,7 +58,7 @@ public class TLSConnectionManager implements Closeable {
         LOG.info("{} - Beginning handshake.", socketChannel.getRemoteAddress());
         try {
             sslEngine.beginHandshake();
-            currentSession = sslEngine.getHandshakeSession();
+            currentSession = sslEngine.getSession();
             initBuffers(currentSession);
 
             HandshakeStatus handshakeStatus = sslEngine.getHandshakeStatus();

--- a/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
+++ b/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
@@ -16,8 +16,6 @@ import java.nio.channels.SocketChannel;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 public class TLSConnectionManager implements Closeable {
@@ -33,8 +31,6 @@ public class TLSConnectionManager implements Closeable {
     private ByteBuffer appInBuffer; // Holds the data we have received and unwrapped
     private ByteBuffer networkOutBuffer; // Holds the data we are sending across the wire
     private ByteBuffer networkInBuffer; // Holds the data we have received from the wire
-
-    ExecutorService executor = Executors.newSingleThreadExecutor();
 
     public TLSConnectionManager(SSLContext sslContext) {
         this.sslContext = sslContext;
@@ -82,19 +78,14 @@ public class TLSConnectionManager implements Closeable {
                 switch (handshakeStatus) {
                     case NEED_TASK:
                         // we need to finish these tasks for the handshake to continue
-                        List<Future<?>> tasks = new ArrayList<>();
+                        List<Runnable> tasks = new ArrayList<>();
                         Runnable currentTask = sslEngine.getDelegatedTask();
                         while(currentTask != null) {
-                            tasks.add(executor.submit(currentTask));
+                            tasks.add(currentTask);
                             currentTask = sslEngine.getDelegatedTask();
                         }
-                        for (Future<?> task : tasks) {
-                            try {
-                                task.get();
-                            } catch (ExecutionException e) {
-                                // TODO make this more clear
-                                throw new RuntimeException(e);
-                            }
+                        for (Runnable task : tasks) {
+                            task.run();
                         }
                         break;
                     case NEED_WRAP:

--- a/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
+++ b/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
@@ -1,5 +1,8 @@
 package net.spy.memcached.tls;
 
+import net.spy.memcached.compat.log.Logger;
+import net.spy.memcached.compat.log.LoggerFactory;
+
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLEngineResult;
@@ -19,7 +22,8 @@ import java.util.concurrent.Future;
 
 public class TLSConnectionManager implements Closeable {
 
-    private final SSLContext sslContext;
+    private static final Logger LOG = LoggerFactory.getLogger(TLSConnectionManager.class);
+
     private final SSLEngine sslEngine;
 
     private SSLSession currentSession;
@@ -32,7 +36,6 @@ public class TLSConnectionManager implements Closeable {
     ExecutorService executor = Executors.newSingleThreadExecutor();
 
     public TLSConnectionManager(SSLContext sslContext) {
-        this.sslContext = sslContext;
         this.sslEngine = sslContext.createSSLEngine();
 
         configureSslEngine();
@@ -52,7 +55,7 @@ public class TLSConnectionManager implements Closeable {
     }
 
     public boolean doHandshake(SocketChannel socketChannel) throws IOException {
-
+        LOG.info("{} - Beginning handshake.", socketChannel.getRemoteAddress());
         try {
             sslEngine.beginHandshake();
             currentSession = sslEngine.getHandshakeSession();

--- a/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
+++ b/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
@@ -99,8 +99,8 @@ public class TLSConnectionManager implements Closeable {
                                 return false;
                             }
                             // We're done with the handshake, signal that we aren't going to be sending or receiving any more data
-                            sslEngine.closeOutbound();
                             sslEngine.closeInbound();
+                            sslEngine.closeOutbound();
                             break;
                         }
                         networkInBuffer.flip();

--- a/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
+++ b/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
@@ -1,7 +1,13 @@
 package net.spy.memcached.tls;
 
-import net.spy.memcached.compat.log.Logger;
-import net.spy.memcached.compat.log.LoggerFactory;
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.SocketChannel;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
@@ -9,12 +15,9 @@ import javax.net.ssl.SSLEngineResult;
 import javax.net.ssl.SSLEngineResult.HandshakeStatus;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLSession;
-import java.io.Closeable;
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.channels.SocketChannel;
-import java.util.ArrayList;
-import java.util.List;
+
+import net.spy.memcached.compat.log.Logger;
+import net.spy.memcached.compat.log.LoggerFactory;
 
 public class TLSConnectionManager implements Closeable {
 
@@ -34,8 +37,11 @@ public class TLSConnectionManager implements Closeable {
     private ByteBuffer networkOutBuffer; // Holds the data we are sending across the wire
     private ByteBuffer networkInBuffer; // Holds the data we have received from the wire
 
+    private CountDownLatch handshakeSuccessful;
+
     public TLSConnectionManager(SSLContext sslContext) {
         this.sslContext = sslContext;
+        this.handshakeSuccessful = new CountDownLatch(1);
     }
 
     private void initSslEngine() {
@@ -156,6 +162,7 @@ public class TLSConnectionManager implements Closeable {
         if (LOG.isDebugEnabled()) {
             LOG.debug("%s - Handshake complete.", socketChannel.getRemoteAddress());
         }
+        handshakeSuccessful.countDown();
         return true;
     }
 
@@ -330,5 +337,17 @@ public class TLSConnectionManager implements Closeable {
         public SSLEngineResult getResult() {
             return result;
         }
+    }
+
+    public boolean wasHandshakeSuccessful() {
+        return handshakeSuccessful.getCount() == 0;
+    }
+
+    public boolean awaitHandshake(long msToWait) throws InterruptedException {
+       return handshakeSuccessful.await(msToWait, TimeUnit.MILLISECONDS);
+    }
+
+    public void resetHandshakeStatus() {
+        handshakeSuccessful = new CountDownLatch(1);
     }
 }

--- a/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
+++ b/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
@@ -107,7 +107,7 @@ public class TLSConnectionManager implements Closeable {
                         ByteBuffer bufferContent = networkOutBuffer.duplicate();
                         ArrayList<Byte> bytes = new ArrayList<>();
                         for(int i = 0; i < bufferContent.remaining(); i++) {
-                            bufferContent.put(bufferContent.get());
+                            bytes.add(bufferContent.get());
                         }
                         SSLEngineResult unwrapResult = sslEngine.unwrap(networkInBuffer, appInBuffer);
                         networkOutBuffer.compact(); // Leaves any unread bytes while creating more room in the buffer

--- a/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
+++ b/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
@@ -55,7 +55,7 @@ public class TLSConnectionManager implements Closeable {
     }
 
     public boolean doHandshake(SocketChannel socketChannel) throws IOException {
-        LOG.info("{} - Beginning handshake.", socketChannel.getRemoteAddress());
+        LOG.info("%s - Beginning handshake.", socketChannel.getRemoteAddress());
         try {
             sslEngine.beginHandshake();
             currentSession = sslEngine.getSession();
@@ -65,7 +65,7 @@ public class TLSConnectionManager implements Closeable {
             while (!Thread.currentThread().isInterrupted()
                     && handshakeStatus != HandshakeStatus.FINISHED
                     && handshakeStatus != HandshakeStatus.NOT_HANDSHAKING) {
-                LOG.info("{} - Handshake status: {}", socketChannel.getRemoteAddress(), handshakeStatus.name());
+                LOG.info("%s - Handshake status: %s", socketChannel.getRemoteAddress(), handshakeStatus.name());
                 switch (handshakeStatus) {
                     case NEED_TASK:
                         // we need to finish these tasks for the handshake to continue

--- a/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
+++ b/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
@@ -117,7 +117,7 @@ public class TLSConnectionManager implements Closeable {
                             } catch (SSLException e) {
                                 if (LOG.isDebugEnabled()) {
                                     // This doesn't seem to be critical, but it could be nice to know about
-                                    LOG.warn("{} - tried to close inbound traffic but has not received a TLS close notification yet due to end of stream.", socketChannel.getRemoteAddress(), e);
+                                    LOG.warn("%s - tried to close inbound traffic but has not received a TLS close notification yet due to end of stream.", socketChannel.getRemoteAddress(), e);
                                 }
                             }
                             sslEngine.closeOutbound();

--- a/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
+++ b/src/main/java/net/spy/memcached/tls/TLSConnectionManager.java
@@ -103,14 +103,9 @@ public class TLSConnectionManager implements Closeable {
                             sslEngine.closeOutbound();
                             break;
                         }
-                        networkOutBuffer.flip();
-                        ByteBuffer bufferContent = networkOutBuffer.duplicate();
-                        ArrayList<Byte> bytes = new ArrayList<>();
-                        for(int i = 0; i < bufferContent.remaining(); i++) {
-                            bytes.add(bufferContent.get());
-                        }
+                        networkInBuffer.flip();
                         SSLEngineResult unwrapResult = sslEngine.unwrap(networkInBuffer, appInBuffer);
-                        networkOutBuffer.compact(); // Leaves any unread bytes while creating more room in the buffer
+                        networkInBuffer.compact(); // Leaves any unread bytes while creating more room in the buffer
                         if (unwrapResult.getStatus() == SSLEngineResult.Status.CLOSED) {
                             return false; // Server closed session before handshake completed
                         }

--- a/src/test/java/net/spy/memcached/MockMemcachedNode.java
+++ b/src/test/java/net/spy/memcached/MockMemcachedNode.java
@@ -32,6 +32,7 @@ import java.nio.channels.SocketChannel;
 import java.util.Collection;
 
 import net.spy.memcached.ops.Operation;
+import net.spy.memcached.tls.TLSConnectionManager;
 
 /**
  * A MockMemcachedNode.
@@ -232,5 +233,10 @@ public class MockMemcachedNode implements MemcachedNode {
 	@Override
 	public boolean executeTlsHandshake() {
 		return true;
+	}
+
+	@Override
+	public TLSConnectionManager.UnwrapResult unwrapReadBuffer(ByteBuffer networkInBuffer) throws IOException {
+		return null;
 	}
 }

--- a/src/test/java/net/spy/memcached/MockMemcachedNode.java
+++ b/src/test/java/net/spy/memcached/MockMemcachedNode.java
@@ -228,4 +228,9 @@ public class MockMemcachedNode implements MemcachedNode {
 	public int pendingOperationQueueSize() {
 		return 0;
 	}
+
+	@Override
+	public boolean executeTlsHandshake() {
+		return true;
+	}
 }


### PR DESCRIPTION
This PR uses the SSLContext provided in #28 to enable support for TLS connections to Memcached. 

Internally, we've built out testing to prove that performance degradation for SASL/Binary connections with this branch is negligible. We are still working on testing the performance impact of enabling TLS, but we believe that this branch should be safe to merge. 