### PR TITLE
fix: throw on invalid binary response header instead of using assert

### DIFF
--- a/src/main/java/net/spy/memcached/protocol/binary/OperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/OperationImpl.java
@@ -161,19 +161,30 @@ public  abstract class OperationImpl extends BaseOperationImpl
   /**
    * Parse the header info out of the buffer.
    */
-  private void parseHeaderFromBuffer() {
+  private void parseHeaderFromBuffer() throws IOException {
     int magic = header[0];
-    assert magic == RES_MAGIC : "Invalid magic:  " + magic;
+    if (magic != RES_MAGIC) {
+      handleError(OperationErrorType.SERVER, "Invalid magic byte: " + magic);
+    }
     responseCmd = header[1];
-    assert cmd == DUMMY_OPCODE || responseCmd == cmd
-      : "Unexpected response command value";
+    if (cmd != DUMMY_OPCODE && responseCmd != cmd) {
+      handleError(
+        OperationErrorType.SERVER,
+        "Unexpected response command value: " + responseCmd
+      );
+    }
     keyLen = decodeShort(header, 2);
     errorCode = decodeShort(header, 6);
     int bytesToRead = decodeInt(header, 8);
     payload = new byte[bytesToRead];
     responseOpaque = decodeInt(header, 12);
     responseCas = decodeLong(header, 16);
-    assert opaqueIsValid() : "Opaque is not valid";
+    if (!opaqueIsValid()) {
+      handleError(
+        OperationErrorType.SERVER,
+        "Opaque is not valid: expected " + opaque + ", got " + responseOpaque
+      );
+    }
   }
 
   /**

--- a/src/test/java/net/spy/memcached/protocol/binary/OperatonTest.java
+++ b/src/test/java/net/spy/memcached/protocol/binary/OperatonTest.java
@@ -22,7 +22,17 @@
 
 package net.spy.memcached.protocol.binary;
 
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.AtomicReference;
+
 import junit.framework.TestCase;
+
+import net.spy.memcached.OperationFactory;
+import net.spy.memcached.ops.GetOperation;
+import net.spy.memcached.ops.OperationException;
+import net.spy.memcached.ops.OperationStatus;
+import net.spy.memcached.ops.StatusCode;
 
 import static net.spy.memcached.protocol.binary.OperationImpl.decodeInt;
 import static net.spy.memcached.protocol.binary.OperationImpl.decodeLong;
@@ -63,5 +73,93 @@ public class OperatonTest extends TestCase {
   public void testOperationStatusString() {
     String s = String.valueOf(OperationImpl.STATUS_OK);
     assertEquals("{OperationStatus success=true:  OK}", s);
+  }
+
+  public void testInvalidMagicRaisesException() {
+    byte[] header = new byte[24];
+    header[0] = (byte) 0x45;
+    header[8] = (byte) 0x6F;
+    header[9] = (byte) 0x20;
+    header[10] = (byte) 0x6D;
+    header[11] = (byte) 0x61;
+
+    AtomicReference<OperationStatus> received = new AtomicReference<>();
+    GetOperation op = newGetOperation(received);
+
+    IOException thrown = null;
+    try {
+      op.readFromBuffer(ByteBuffer.wrap(header));
+    } catch (IOException e) {
+      thrown = e;
+    }
+
+    assertNotNull("Expected IOException for invalid magic byte", thrown);
+    assertTrue(thrown instanceof OperationException);
+    assertTrue(thrown.getMessage().contains("Invalid magic byte"));
+    assertNotNull(received.get());
+    assertFalse(received.get().isSuccess());
+    assertEquals(StatusCode.ERR_INTERNAL, received.get().getStatusCode());
+  }
+
+  public void testMismatchedResponseCmdRaisesException() {
+    byte[] header = new byte[24];
+    header[0] = (byte) 0x81;
+    header[1] = (byte) 0x7A;
+
+    AtomicReference<OperationStatus> received = new AtomicReference<>();
+    GetOperation op = newGetOperation(received);
+
+    IOException thrown = null;
+    try {
+      op.readFromBuffer(ByteBuffer.wrap(header));
+    } catch (IOException e) {
+      thrown = e;
+    }
+
+    assertNotNull("Expected IOException for mismatched response command", thrown);
+    assertTrue(thrown instanceof OperationException);
+    assertTrue(thrown.getMessage().contains("Unexpected response command"));
+    assertEquals(StatusCode.ERR_INTERNAL, received.get().getStatusCode());
+  }
+
+  public void testInvalidOpaqueRaisesException() {
+    byte[] header = new byte[24];
+    header[0] = (byte) 0x81;
+    header[1] = (byte) 0x00;
+    header[12] = (byte) 0x7F;
+    header[13] = (byte) 0xFF;
+    header[14] = (byte) 0xFF;
+    header[15] = (byte) 0xFE;
+
+    AtomicReference<OperationStatus> received = new AtomicReference<>();
+    GetOperation op = newGetOperation(received);
+
+    IOException thrown = null;
+    try {
+      op.readFromBuffer(ByteBuffer.wrap(header));
+    } catch (IOException e) {
+      thrown = e;
+    }
+
+    assertNotNull("Expected IOException for invalid opaque", thrown);
+    assertTrue(thrown instanceof OperationException);
+    assertTrue(thrown.getMessage().contains("Opaque is not valid"));
+    assertEquals(StatusCode.ERR_INTERNAL, received.get().getStatusCode());
+  }
+
+  private static GetOperation newGetOperation(
+      final AtomicReference<OperationStatus> received) {
+    OperationFactory opFact = new BinaryOperationFactory();
+    return opFact.get("key", new GetOperation.Callback() {
+      public void receivedStatus(OperationStatus s) {
+        received.set(s);
+      }
+
+      public void gotData(String k, int flags, byte[] data) {
+      }
+
+      public void complete() {
+      }
+    });
   }
 }


### PR DESCRIPTION
Context: https://hubspot.slack.com/archives/C0137SDV26B/p1776715812662809

HubSpot services run with assertions disabled in production, so the `assert magic == RES_MAGIC` check in `OperationImpl#parseHeaderFromBuffer` was silently bypassed when a non-binary response (e.g. a plain-text "ERROR Too many open conn..." from a misconfigured intermediary) was received. The method then read a 4-byte "body length" from offsets 8..11 of that payload and attempted `new byte[bytesToRead]`, triggering an ~1.8 GB allocation and an OutOfMemoryError in production.

Replace the asserts on `RES_MAGIC`, response command match, and opaque validity with calls to the existing `handleError(OperationErrorType, ...)` helper. `handleError` throws `OperationException` (an `IOException` subclass) which `readFromBuffer` already declares, so the error flows through the normal connection-error path and the dangerous allocation is never reached.

🤖 Generated with Claude Code